### PR TITLE
Update Readme and replace deprecated .branch("main")

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once you have your Swift package set up, adding OpenAI as a dependency is as eas
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/MacPaw/OpenAI.git", .branch("main"))
+    .package(url: "https://github.com/MacPaw/OpenAI.git", branch: "main")
 ]
 ```
 


### PR DESCRIPTION
The usage of .branch("main") is deprecated and should be replaced with branch: "main"