### PR TITLE
Simplify interface by moving timeout to configuration. Add organizati…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Once you have a token, you can initialize `OpenAI` class, which is an entry poin
 let openAI = OpenAI(apiToken: "YOUR_TOKEN_HERE")
 ```
 
+Optionally you can initialize `OpenAI` with token, organization identifier and timeoutInterval.
+
+```swift
+let configuration = OpenAI.Configuration(token: "YOUR_TOKEN_HERE", organizationIdentifier: "YOUR_ORGANIZATION_ID_HERE", timeoutInterval: 60.0)
+let openAI = OpenAI(configuration: configuration)
+```
+
 Once token you posses the token, and the instance is initialized you are ready to make requests.
 
 ### Completions

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -22,6 +22,7 @@ final public class OpenAI: OpenAIProtocol {
         
         /// Default request timeout
         public let timeoutInterval: TimeInterval
+        
         public init(token: String, organizationIdentifier: String? = nil, timeoutInterval: TimeInterval = 60.0) {
             self.token = token
             self.organizationIdentifier = organizationIdentifier
@@ -30,6 +31,7 @@ final public class OpenAI: OpenAIProtocol {
     }
     
     private let session: URLSessionProtocol
+    
     public let configuration: Configuration
 
     public convenience init(apiToken: String) {

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -17,7 +17,7 @@ final public class OpenAI: OpenAIProtocol {
         /// OpenAI API token. See https://platform.openai.com/docs/api-reference/authentication
         public let token: String
         
-        /// Optional OpenAI organization identifie. See https://platform.openai.com/docs/api-reference/authentication
+        /// Optional OpenAI organization identifier. See https://platform.openai.com/docs/api-reference/authentication
         public let organizationIdentifier: String?
         
         /// Default request timeout

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -12,40 +12,61 @@ import FoundationNetworking
 
 final public class OpenAI: OpenAIProtocol {
 
-    private let apiToken: String
-    private let session: URLSessionProtocol
-
-    public convenience init(apiToken: String) {
-        self.init(apiToken: apiToken, session: URLSession.shared)
+    public struct Configuration {
+        
+        /// OpenAI API token. See https://platform.openai.com/docs/api-reference/authentication
+        public let token: String
+        
+        /// Optional OpenAI organization identifie. See https://platform.openai.com/docs/api-reference/authentication
+        public let organizationIdentifier: String?
+        
+        /// Default request timeout
+        public let timeoutInterval: TimeInterval
+        public init(token: String, organizationIdentifier: String? = nil, timeoutInterval: TimeInterval = 60.0) {
+            self.token = token
+            self.organizationIdentifier = organizationIdentifier
+            self.timeoutInterval = timeoutInterval
+        }
     }
     
-    init(apiToken: String, session: URLSessionProtocol = URLSession.shared) {
-        self.apiToken = apiToken
+    private let session: URLSessionProtocol
+    public let configuration: Configuration
+
+    public convenience init(apiToken: String) {
+        self.init(configuration: Configuration(token: apiToken), session: URLSession.shared)
+    }
+    
+    public convenience init(configuration: Configuration) {
+        self.init(configuration: configuration, session: URLSession.shared)
+    }
+    
+    init(configuration: Configuration, session: URLSessionProtocol = URLSession.shared) {
+        self.configuration = configuration
         self.session = session
     }
     
-    public func completions(query: CompletionsQuery, timeoutInterval: TimeInterval = 60.0, completion: @escaping (Result<CompletionsResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<CompletionsResult>(body: query, url: .completions, timeoutInterval: timeoutInterval), completion: completion)
+    public func completions(query: CompletionsQuery, completion: @escaping (Result<CompletionsResult, Error>) -> Void) {
+        performRequest(request: JSONRequest<CompletionsResult>(body: query, url: .completions), completion: completion)
     }
     
-    public func images(query: ImagesQuery, timeoutInterval: TimeInterval = 60.0, completion: @escaping (Result<ImagesResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<ImagesResult>(body: query, url: .images, timeoutInterval: timeoutInterval), completion: completion)
+    public func images(query: ImagesQuery, completion: @escaping (Result<ImagesResult, Error>) -> Void) {
+        performRequest(request: JSONRequest<ImagesResult>(body: query, url: .images), completion: completion)
     }
     
-    public func embeddings(query: EmbeddingsQuery, timeoutInterval: TimeInterval = 60.0, completion: @escaping (Result<EmbeddingsResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<EmbeddingsResult>(body: query, url: .embeddings, timeoutInterval: timeoutInterval), completion: completion)
+    public func embeddings(query: EmbeddingsQuery, completion: @escaping (Result<EmbeddingsResult, Error>) -> Void) {
+        performRequest(request: JSONRequest<EmbeddingsResult>(body: query, url: .embeddings), completion: completion)
     }
     
-    public func chats(query: ChatQuery, timeoutInterval: TimeInterval = 60.0, completion: @escaping (Result<ChatResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<ChatResult>(body: query, url: .chats, timeoutInterval: timeoutInterval), completion: completion)
+    public func chats(query: ChatQuery, completion: @escaping (Result<ChatResult, Error>) -> Void) {
+        performRequest(request: JSONRequest<ChatResult>(body: query, url: .chats), completion: completion)
     }
     
-    public func audioTransciptions(query: AudioTranscriptionQuery, timeoutInterval: TimeInterval = 60.0, completion: @escaping (Result<AudioTranscriptionResult, Error>) -> Void) {
-        performRequest(request: MultipartFormDataRequest<AudioTranscriptionResult>(body: query, url: .audioTranscriptions, timeoutInterval: timeoutInterval), completion: completion)
+    public func audioTransciptions(query: AudioTranscriptionQuery, completion: @escaping (Result<AudioTranscriptionResult, Error>) -> Void) {
+        performRequest(request: MultipartFormDataRequest<AudioTranscriptionResult>(body: query, url: .audioTranscriptions), completion: completion)
     }
     
-    public func audioTranslations(query: AudioTranslationQuery, timeoutInterval: TimeInterval = 60.0, completion: @escaping (Result<AudioTranslationResult, Error>) -> Void) {
-        performRequest(request: MultipartFormDataRequest<AudioTranslationResult>(body: query, url: .audioTranslations, timeoutInterval: timeoutInterval), completion: completion)
+    public func audioTranslations(query: AudioTranslationQuery, completion: @escaping (Result<AudioTranslationResult, Error>) -> Void) {
+        performRequest(request: MultipartFormDataRequest<AudioTranslationResult>(body: query, url: .audioTranslations), completion: completion)
     }
 }
 
@@ -53,7 +74,7 @@ extension OpenAI {
 
     func performRequest<ResultType: Codable>(request: any URLRequestBuildable, completion: @escaping (Result<ResultType, Error>) -> Void) {
         do {
-            let request = try request.build(token: apiToken)
+            let request = try request.build(token: configuration.token, organizationIdentifier: configuration.organizationIdentifier, timeoutInterval: configuration.timeoutInterval)
             let task = session.dataTask(with: request) { data, _, error in
                 if let error = error {
                     completion(.failure(error))

--- a/Sources/OpenAI/Private/JSONRequest.swift
+++ b/Sources/OpenAI/Private/JSONRequest.swift
@@ -14,23 +14,24 @@ final class JSONRequest<ResultType> {
     
     let body: Codable
     let url: URL
-    let timeoutInterval: TimeInterval
     let method: String
     
-    init(body: Codable, url: URL, method: String = "POST", timeoutInterval: TimeInterval) {
+    init(body: Codable, url: URL, method: String = "POST") {
         self.body = body
         self.url = url
         self.method = method
-        self.timeoutInterval = timeoutInterval
     }
 }
 
 extension JSONRequest: URLRequestBuildable {
     
-    func build(token: String) throws -> URLRequest {
+    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval) throws -> URLRequest {
         var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let organizationIdentifier {
+            request.setValue(organizationIdentifier, forHTTPHeaderField: "OpenAI-Organization")
+        }
         request.httpMethod = method
         request.httpBody = try JSONEncoder().encode(body)
         return request

--- a/Sources/OpenAI/Private/MultipartFormDataRequest.swift
+++ b/Sources/OpenAI/Private/MultipartFormDataRequest.swift
@@ -14,26 +14,27 @@ final class MultipartFormDataRequest<ResultType> {
     
     let body: MultipartFormDataBodyEncodable
     let url: URL
-    let timeoutInterval: TimeInterval
     let method: String
         
-    init(body: MultipartFormDataBodyEncodable, url: URL, method: String = "POST", timeoutInterval: TimeInterval) {
+    init(body: MultipartFormDataBodyEncodable, url: URL, method: String = "POST") {
         self.body = body
         self.url = url
         self.method = method
-        self.timeoutInterval = timeoutInterval
     }
 }
 
 extension MultipartFormDataRequest: URLRequestBuildable {
     
-    func build(token: String) throws -> URLRequest {
+    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval) throws -> URLRequest {
         var request = URLRequest(url: url)
         let boundary: String = UUID().uuidString
         request.timeoutInterval = timeoutInterval
         request.httpMethod = method
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        if let organizationIdentifier {
+            request.setValue(organizationIdentifier, forHTTPHeaderField: "OpenAI-Organization")
+        }
         request.httpBody = body.encode(boundary: boundary)
         return request
     }

--- a/Sources/OpenAI/Private/URLRequestBuildable.swift
+++ b/Sources/OpenAI/Private/URLRequestBuildable.swift
@@ -14,5 +14,5 @@ protocol URLRequestBuildable {
     
     associatedtype ResultType
     
-    func build(token: String) throws -> URLRequest
+    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval) throws -> URLRequest
 }

--- a/Sources/OpenAI/Public/Errors/APIError.swift
+++ b/Sources/OpenAI/Public/Errors/APIError.swift
@@ -19,6 +19,20 @@ public struct APIError: Error, Decodable, Equatable {
     public let code: String?
 }
 
-public struct APIErrorResponse: Error, Decodable {
+extension APIError: LocalizedError {
+    
+    public var errorDescription: String? {
+        return message
+    }
+}
+
+public struct APIErrorResponse: Error, Decodable, Equatable {
     public let error: APIError
+}
+
+extension APIErrorResponse: LocalizedError {
+    
+    public var errorDescription: String? {
+        return error.errorDescription
+    }
 }

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Extensions.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Extensions.swift
@@ -13,11 +13,10 @@ import Foundation
 @available(watchOS 6.0, *)
 public extension OpenAIProtocol {
     func completions(
-        query: CompletionsQuery,
-        timeoutInterval: TimeInterval = 60.0
+        query: CompletionsQuery
     ) async throws -> CompletionsResult {
         try await withCheckedThrowingContinuation { continuation in
-            completions(query: query, timeoutInterval: timeoutInterval) { result in
+            completions(query: query) { result in
                 switch result {
                 case let .success(success):
                     return continuation.resume(returning: success)
@@ -29,11 +28,10 @@ public extension OpenAIProtocol {
     }
 
     func images(
-        query: ImagesQuery,
-        timeoutInterval: TimeInterval = 60.0
+        query: ImagesQuery
     ) async throws -> ImagesResult {
         try await withCheckedThrowingContinuation { continuation in
-            images(query: query, timeoutInterval: timeoutInterval) { result in
+            images(query: query) { result in
                 switch result {
                 case let .success(success):
                     return continuation.resume(returning: success)
@@ -45,11 +43,10 @@ public extension OpenAIProtocol {
     }
 
     func embeddings(
-        query: EmbeddingsQuery,
-        timeoutInterval: TimeInterval = 60.0
+        query: EmbeddingsQuery
     ) async throws -> EmbeddingsResult {
         try await withCheckedThrowingContinuation { continuation in
-            embeddings(query: query, timeoutInterval: timeoutInterval) { result in
+            embeddings(query: query) { result in
                 switch result {
                 case let .success(success):
                     return continuation.resume(returning: success)
@@ -61,11 +58,10 @@ public extension OpenAIProtocol {
     }
     
     func chats(
-        query: ChatQuery,
-        timeoutInterval: TimeInterval = 60.0
+        query: ChatQuery
     ) async throws -> ChatResult {
         try await withCheckedThrowingContinuation { continuation in
-            chats(query: query, timeoutInterval: timeoutInterval) { result in
+            chats(query: query) { result in
                 switch result {
                 case let .success(success):
                     return continuation.resume(returning: success)
@@ -77,11 +73,10 @@ public extension OpenAIProtocol {
     }
     
     func audioTransciptions(
-        query: AudioTranscriptionQuery,
-        timeoutInterval: TimeInterval = 60.0
+        query: AudioTranscriptionQuery
     ) async throws -> AudioTranscriptionResult {
         try await withCheckedThrowingContinuation { continuation in
-            audioTransciptions(query: query, timeoutInterval: timeoutInterval) { result in
+            audioTransciptions(query: query) { result in
                 switch result {
                 case let .success(success):
                     return continuation.resume(returning: success)
@@ -93,11 +88,10 @@ public extension OpenAIProtocol {
     }
     
     func audioTranslations(
-        query: AudioTranslationQuery,
-        timeoutInterval: TimeInterval = 60.0
+        query: AudioTranslationQuery
     ) async throws -> AudioTranslationResult {
         try await withCheckedThrowingContinuation { continuation in
-            audioTranslations(query: query, timeoutInterval: timeoutInterval) { result in
+            audioTranslations(query: query) { result in
                 switch result {
                 case let .success(success):
                     return continuation.resume(returning: success)

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -22,10 +22,9 @@ public protocol OpenAIProtocol {
      
      - Parameters:
        - query: A `CompletionsQuery` object containing the input parameters for the API request. This includes the prompt, model, temperature, max tokens, and other settings.
-       - timeoutInterval: A `TimeInterval` specifying the timeout for the API request. If the specified interval elapses before the API request completes, the function will return an error.
        - completion: A closure which receives the result when the API request finishes. The closure's parameter, `Result<CompletionsResult, Error>`, will contain either the `CompletionsResult` object with the generated completions, or an error if the request failed.
     **/
-    func completions(query: CompletionsQuery, timeoutInterval: TimeInterval, completion: @escaping (Result<CompletionsResult, Error>) -> Void)
+    func completions(query: CompletionsQuery, completion: @escaping (Result<CompletionsResult, Error>) -> Void)
     
     /**
      This function sends an images query to the OpenAI API and retrieves generated images in response. The Images Generation API enables you to create various images or graphics using OpenAI's powerful deep learning models.
@@ -40,10 +39,9 @@ public protocol OpenAIProtocol {
      
      - Parameters:
        - query: An `ImagesQuery` object containing the input parameters for the API request. This includes the query parameters such as the model, text prompt, image size, and other settings.
-       - timeoutInterval: A `TimeInterval` specifying the timeout for the API request. If the specified interval elapses before the API request completes, the function will return an error.
        - completion: A closure which receives the result when the API request finishes. The closure's parameter, `Result<ImagesResult, Error>`, will contain either the `ImagesResult` object with the generated images, or an error if the request failed.
     **/
-    func images(query: ImagesQuery, timeoutInterval: TimeInterval, completion: @escaping (Result<ImagesResult, Error>) -> Void)
+    func images(query: ImagesQuery, completion: @escaping (Result<ImagesResult, Error>) -> Void)
     
     /**
      This function sends an embeddings query to the OpenAI API and retrieves embeddings in response. The Embeddings API enables you to generate high-dimensional vector representations of texts, which can be used for various natural language processing tasks such as semantic similarity, clustering, and classification.
@@ -58,10 +56,9 @@ public protocol OpenAIProtocol {
      
      - Parameters:
        - query: An `EmbeddingsQuery` object containing the input parameters for the API request. This includes the list of text prompts to be converted into embeddings, the model to be used, and other settings.
-       - timeoutInterval: A `TimeInterval` specifying the timeout for the API request. If the specified interval elapses before the API request completes, the function will return an error.
        - completion: A closure which receives the result when the API request finishes. The closure's parameter, `Result<EmbeddingsResult, Error>`, will contain either the `EmbeddingsResult` object with the generated embeddings, or an error if the request failed.
     **/
-    func embeddings(query: EmbeddingsQuery, timeoutInterval: TimeInterval, completion: @escaping (Result<EmbeddingsResult, Error>) -> Void)
+    func embeddings(query: EmbeddingsQuery, completion: @escaping (Result<EmbeddingsResult, Error>) -> Void)
     
     /**
      This function sends a chat query to the OpenAI API and retrieves chat conversation responses. The Chat API enables you to build chatbots or conversational applications using OpenAI's powerful natural language models, like GPT-3.
@@ -76,28 +73,25 @@ public protocol OpenAIProtocol {
 
      - Parameters:
        - query: A `ChatQuery` object containing the input parameters for the API request. This includes the lists of message objects for the conversation, the model to be used, and other settings.
-       - timeoutInterval: A `TimeInterval` specifying the timeout for the API request. If the specified interval elapses before the API request completes, the function will return an error.
        - completion: A closure which receives the result when the API request finishes. The closure's parameter, `Result<ChatResult, Error>`, will contain either the `ChatResult` object with the model's response to the conversation, or an error if the request failed.
     **/
-    func chats(query: ChatQuery, timeoutInterval: TimeInterval, completion: @escaping (Result<ChatResult, Error>) -> Void)
+    func chats(query: ChatQuery, completion: @escaping (Result<ChatResult, Error>) -> Void)
     
     /**
     Transcribes audio data using OpenAI's audio transcription API and completes the operation asynchronously.
 
     - Parameter query: The `AudioTranscriptionQuery` instance, containing the information required for the transcription request.
-    - Parameter timeoutInterval: The `TimeInterval` (in seconds) specifying the maximum duration to wait for the transcription request to complete.
     - Parameter completion: The completion handler to be executed upon completion of the transcription request.
                           Returns a `Result` of type `AudioTranscriptionResult` if successful, or an `Error` if an error occurs.
      **/
-    func audioTransciptions(query: AudioTranscriptionQuery, timeoutInterval: TimeInterval, completion: @escaping (Result<AudioTranscriptionResult, Error>) -> Void)
+    func audioTransciptions(query: AudioTranscriptionQuery, completion: @escaping (Result<AudioTranscriptionResult, Error>) -> Void)
     
     /**
     Translates audio data using OpenAI's audio translation API and completes the operation asynchronously.
 
     - Parameter query: The `AudioTranslationQuery` instance, containing the information required for the translation request.
-    - Parameter timeoutInterval: The `TimeInterval` (in seconds) specifying the maximum duration to wait for the translation request to complete.
     - Parameter completion: The completion handler to be executed upon completion of the translation request.
                          Returns a `Result` of type `AudioTranslationResult` if successful, or an `Error` if an error occurs.
      **/
-    func audioTranslations(query: AudioTranslationQuery, timeoutInterval: TimeInterval, completion: @escaping (Result<AudioTranslationResult, Error>) -> Void)
+    func audioTranslations(query: AudioTranslationQuery, completion: @escaping (Result<AudioTranslationResult, Error>) -> Void)
 }


### PR DESCRIPTION
## What

* Simplify the interface by moving timeout to configuration. 
* Add organization identifier. 
* Add unit tests.

## Why

We need the ability to specify organization identifiers.

## Affected Areas

Library initialization. 
