### PR TITLE
Custom host option has been added

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -52,27 +52,27 @@ final public class OpenAI: OpenAIProtocol {
     }
     
     public func completions(query: CompletionsQuery, completion: @escaping (Result<CompletionsResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<CompletionsResult>(body: query, url: apiURL(path: .completions)), completion: completion)
+        performRequest(request: JSONRequest<CompletionsResult>(body: query, url: buildURL(path: .completions)), completion: completion)
     }
     
     public func images(query: ImagesQuery, completion: @escaping (Result<ImagesResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<ImagesResult>(body: query, url: apiURL(path: .images)), completion: completion)
+        performRequest(request: JSONRequest<ImagesResult>(body: query, url: buildURL(path: .images)), completion: completion)
     }
     
     public func embeddings(query: EmbeddingsQuery, completion: @escaping (Result<EmbeddingsResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<EmbeddingsResult>(body: query, url: apiURL(path: .embeddings)), completion: completion)
+        performRequest(request: JSONRequest<EmbeddingsResult>(body: query, url: buildURL(path: .embeddings)), completion: completion)
     }
     
     public func chats(query: ChatQuery, completion: @escaping (Result<ChatResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<ChatResult>(body: query, url: apiURL(path: .chats)), completion: completion)
+        performRequest(request: JSONRequest<ChatResult>(body: query, url: buildURL(path: .chats)), completion: completion)
     }
     
     public func audioTransciptions(query: AudioTranscriptionQuery, completion: @escaping (Result<AudioTranscriptionResult, Error>) -> Void) {
-        performRequest(request: MultipartFormDataRequest<AudioTranscriptionResult>(body: query, url: apiURL(path: .audioTranscriptions)), completion: completion)
+        performRequest(request: MultipartFormDataRequest<AudioTranscriptionResult>(body: query, url: buildURL(path: .audioTranscriptions)), completion: completion)
     }
     
     public func audioTranslations(query: AudioTranslationQuery, completion: @escaping (Result<AudioTranslationResult, Error>) -> Void) {
-        performRequest(request: MultipartFormDataRequest<AudioTranslationResult>(body: query, url: apiURL(path: .audioTranslations)), completion: completion)
+        performRequest(request: MultipartFormDataRequest<AudioTranslationResult>(body: query, url: buildURL(path: .audioTranslations)), completion: completion)
     }
 }
 
@@ -118,7 +118,7 @@ extension OpenAI {
 
 internal extension OpenAI {
     
-    func apiURL(path: String) -> URL {
+    func buildURL(path: String) -> URL {
         var components = URLComponents()
         components.scheme = "https"
         components.host = configuration.host

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -20,12 +20,16 @@ final public class OpenAI: OpenAIProtocol {
         /// Optional OpenAI organization identifier. See https://platform.openai.com/docs/api-reference/authentication
         public let organizationIdentifier: String?
         
+        /// API host. Set this property if you use some kind of proxy or your own server. Default is api.openai.com
+        public let host: String
+        
         /// Default request timeout
         public let timeoutInterval: TimeInterval
         
-        public init(token: String, organizationIdentifier: String? = nil, timeoutInterval: TimeInterval = 60.0) {
+        public init(token: String, organizationIdentifier: String? = nil, host: String = "api.openai.com", timeoutInterval: TimeInterval = 60.0) {
             self.token = token
             self.organizationIdentifier = organizationIdentifier
+            self.host = host
             self.timeoutInterval = timeoutInterval
         }
     }
@@ -48,27 +52,27 @@ final public class OpenAI: OpenAIProtocol {
     }
     
     public func completions(query: CompletionsQuery, completion: @escaping (Result<CompletionsResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<CompletionsResult>(body: query, url: .completions), completion: completion)
+        performRequest(request: JSONRequest<CompletionsResult>(body: query, url: apiURL(path: .completions)), completion: completion)
     }
     
     public func images(query: ImagesQuery, completion: @escaping (Result<ImagesResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<ImagesResult>(body: query, url: .images), completion: completion)
+        performRequest(request: JSONRequest<ImagesResult>(body: query, url: apiURL(path: .images)), completion: completion)
     }
     
     public func embeddings(query: EmbeddingsQuery, completion: @escaping (Result<EmbeddingsResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<EmbeddingsResult>(body: query, url: .embeddings), completion: completion)
+        performRequest(request: JSONRequest<EmbeddingsResult>(body: query, url: apiURL(path: .embeddings)), completion: completion)
     }
     
     public func chats(query: ChatQuery, completion: @escaping (Result<ChatResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<ChatResult>(body: query, url: .chats), completion: completion)
+        performRequest(request: JSONRequest<ChatResult>(body: query, url: apiURL(path: .chats)), completion: completion)
     }
     
     public func audioTransciptions(query: AudioTranscriptionQuery, completion: @escaping (Result<AudioTranscriptionResult, Error>) -> Void) {
-        performRequest(request: MultipartFormDataRequest<AudioTranscriptionResult>(body: query, url: .audioTranscriptions), completion: completion)
+        performRequest(request: MultipartFormDataRequest<AudioTranscriptionResult>(body: query, url: apiURL(path: .audioTranscriptions)), completion: completion)
     }
     
     public func audioTranslations(query: AudioTranslationQuery, completion: @escaping (Result<AudioTranslationResult, Error>) -> Void) {
-        performRequest(request: MultipartFormDataRequest<AudioTranslationResult>(body: query, url: .audioTranslations), completion: completion)
+        performRequest(request: MultipartFormDataRequest<AudioTranslationResult>(body: query, url: apiURL(path: .audioTranslations)), completion: completion)
     }
 }
 
@@ -112,13 +116,25 @@ extension OpenAI {
     }
 }
 
-internal extension URL {
-
-    static let completions = URL(string: "https://api.openai.com/v1/completions")!
-    static let images = URL(string: "https://api.openai.com/v1/images/generations")!
-    static let embeddings = URL(string: "https://api.openai.com/v1/embeddings")!
-    static let chats = URL(string: "https://api.openai.com/v1/chat/completions")!
+internal extension OpenAI {
     
-    static let audioTranscriptions = URL(string: "https://api.openai.com/v1/audio/transcriptions")!
-    static let audioTranslations = URL(string: "https://api.openai.com/v1/audio/translations")!
+    func apiURL(path: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = configuration.host
+        components.path = path
+        return components.url!
+    }
+}
+
+internal typealias APIPath = String
+internal extension APIPath {
+    
+    static let completions = "/v1/completions"
+    static let images = "/v1/images/generations"
+    static let embeddings = "/v1/embeddings"
+    static let chats = "/v1/chat/completions"
+    
+    static let audioTranscriptions = "/v1/audio/transcriptions"
+    static let audioTranslations = "/v1/audio/translations"
 }

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -116,7 +116,7 @@ extension OpenAI {
     }
 }
 
-internal extension OpenAI {
+extension OpenAI {
     
     func buildURL(path: String) -> URL {
         var components = URLComponents()
@@ -127,8 +127,8 @@ internal extension OpenAI {
     }
 }
 
-internal typealias APIPath = String
-internal extension APIPath {
+typealias APIPath = String
+extension APIPath {
     
     static let completions = "/v1/completions"
     static let images = "/v1/images/generations"

--- a/Sources/OpenAI/Public/Errors/APIError.swift
+++ b/Sources/OpenAI/Public/Errors/APIError.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 public enum OpenAIError: Error {
-    case invalidURL
     case emptyData
 }
 

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -162,7 +162,7 @@ final class OpenAITests: XCTestCase {
     func testJSONReqestCreation() throws {
         let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", timeoutInterval: 14)
         let completionQuery = CompletionsQuery(model: .whisper_1, prompt: "how are you?")
-        let jsonRequest = JSONRequest<CompletionsResult>(body: completionQuery, url: .audioTranscriptions)
+        let jsonRequest = JSONRequest<CompletionsResult>(body: completionQuery, url: URL(string: "http://google.com")!)
         let urlRequest = try jsonRequest.build(token: configuration.token, organizationIdentifier: configuration.organizationIdentifier, timeoutInterval: configuration.timeoutInterval)
         
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Authorization"), "Bearer \(configuration.token)")
@@ -174,12 +174,26 @@ final class OpenAITests: XCTestCase {
     func testMultipartReqestCreation() throws {
         let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", timeoutInterval: 14)
         let completionQuery = AudioTranslationQuery(file: Data(), fileName: "foo", model: .whisper_1)
-        let jsonRequest = MultipartFormDataRequest<CompletionsResult>(body: completionQuery, url: .audioTranscriptions)
+        let jsonRequest = MultipartFormDataRequest<CompletionsResult>(body: completionQuery, url: URL(string: "http://google.com")!)
         let urlRequest = try jsonRequest.build(token: configuration.token, organizationIdentifier: configuration.organizationIdentifier, timeoutInterval: configuration.timeoutInterval)
         
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Authorization"), "Bearer \(configuration.token)")
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "OpenAI-Organization"), configuration.organizationIdentifier)
         XCTAssertEqual(urlRequest.timeoutInterval, configuration.timeoutInterval)
+    }
+    
+    func testDefaultHostURLBuilt() {
+        let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", timeoutInterval: 14)
+        let openAI = OpenAI(configuration: configuration, session: self.urlSession)
+        let completionsURL = openAI.apiURL(path: .completions)
+        XCTAssertEqual(completionsURL, URL(string: "https://api.openai.com/v1/completions"))
+    }
+    
+    func testCustomURLBuilt() {
+        let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", host: "my.host.com", timeoutInterval: 14)
+        let openAI = OpenAI(configuration: configuration, session: self.urlSession)
+        let completionsURL = openAI.apiURL(path: .completions)
+        XCTAssertEqual(completionsURL, URL(string: "https://my.host.com/v1/completions"))
     }
 }
 

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -185,14 +185,14 @@ final class OpenAITests: XCTestCase {
     func testDefaultHostURLBuilt() {
         let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", timeoutInterval: 14)
         let openAI = OpenAI(configuration: configuration, session: self.urlSession)
-        let completionsURL = openAI.apiURL(path: .completions)
+        let completionsURL = openAI.buildURL(path: .completions)
         XCTAssertEqual(completionsURL, URL(string: "https://api.openai.com/v1/completions"))
     }
     
     func testCustomURLBuilt() {
         let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", host: "my.host.com", timeoutInterval: 14)
         let openAI = OpenAI(configuration: configuration, session: self.urlSession)
-        let completionsURL = openAI.apiURL(path: .completions)
+        let completionsURL = openAI.buildURL(path: .completions)
         XCTAssertEqual(completionsURL, URL(string: "https://my.host.com/v1/completions"))
     }
 }


### PR DESCRIPTION
## What

A custom host option has been added to the configuration.

```swift
    public struct Configuration {
        
        /// OpenAI API token. See https://platform.openai.com/docs/api-reference/authentication
        public let token: String
        
        /// Optional OpenAI organization identifier. See https://platform.openai.com/docs/api-reference/authentication
        public let organizationIdentifier: String?
        
        /// API host. Set this property if you use some kind of proxy or your own server. Default is api.openai.com
        public let host: String
        
        /// Default request timeout
        public let timeoutInterval: TimeInterval
        
        public init(token: String, organizationIdentifier: String? = nil, host: String = "api.openai.com", timeoutInterval: TimeInterval = 60.0) {
            self.token = token
            self.organizationIdentifier = organizationIdentifier
            self.host = host
            self.timeoutInterval = timeoutInterval
        }
    }
```

## Why

A custom host is useful when using a proxy, or own server implementation. 
More details:  https://github.com/MacPaw/OpenAI/issues/27

## Affected Areas

Initialization, network calls. 

Closes #27 