### PR TITLE
Add usage structure to completions and embeddings

### DIFF
--- a/Sources/OpenAI/Public/Models/CompletionsResult.swift
+++ b/Sources/OpenAI/Public/Models/CompletionsResult.swift
@@ -9,6 +9,18 @@ import Foundation
 
 public struct CompletionsResult: Codable, Equatable {
     
+    public struct Usage: Codable, Equatable {
+        public let promptTokens: Int
+        public let completionTokens: Int
+        public let totalTokens: Int
+        
+        enum CodingKeys: String, CodingKey {
+            case promptTokens = "prompt_tokens"
+            case completionTokens = "completion_tokens"
+            case totalTokens = "total_tokens"
+        }
+    }
+    
     public struct Choice: Codable, Equatable {
         public let text: String
         public let index: Int
@@ -19,4 +31,5 @@ public struct CompletionsResult: Codable, Equatable {
     public let created: TimeInterval
     public let model: Model
     public let choices: [Choice]
+    public let usage: Usage
 }

--- a/Sources/OpenAI/Public/Models/EmbeddingsResult.swift
+++ b/Sources/OpenAI/Public/Models/EmbeddingsResult.swift
@@ -14,5 +14,17 @@ public struct EmbeddingsResult: Codable, Equatable {
         public let embedding: [Double]
         public let index: Int
     }
+    
+    public struct Usage: Codable, Equatable {
+        public let promptTokens: Int
+        public let totalTokens: Int
+        
+        enum CodingKeys: String, CodingKey {
+            case promptTokens = "prompt_tokens"
+            case totalTokens = "total_tokens"
+        }
+    }
+    
     public let data: [Embedding]
+    public let usage: Usage
 }

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -20,7 +20,7 @@ class OpenAITests: XCTestCase {
         let query = CompletionsQuery(model: .textDavinci_003, prompt: "What is 42?", temperature: 0, maxTokens: 100, topP: 1, frequencyPenalty: 0, presencePenalty: 0, stop: ["\\n"])
         let expectedResult = CompletionsResult(id: "foo", object: "bar", created: 100500, model: .babbage, choices: [
             .init(text: "42 is the answer to everything", index: 0)
-        ])
+        ], usage: .init(promptTokens: 10, completionTokens: 10, totalTokens: 20))
         try self.stub(result: expectedResult)
         
         let result = try await openAI.completions(query: query)
@@ -89,7 +89,7 @@ class OpenAITests: XCTestCase {
             .init(object: "id-sdasd", embedding: [0.1, 0.2, 0.3, 0.4], index: 0),
             .init(object: "id-sdasd1", embedding: [0.4, 0.1, 0.7, 0.1], index: 1),
             .init(object: "id-sdasd2", embedding: [0.8, 0.1, 0.2, 0.8], index: 2)
-        ])
+        ], usage: .init(promptTokens: 10, totalTokens: 10))
         try self.stub(result: embeddingsResult)
         
         let result = try await openAI.embeddings(query: query)

--- a/Tests/OpenAITests/OpenAITestsCombine.swift
+++ b/Tests/OpenAITests/OpenAITestsCombine.swift
@@ -29,7 +29,7 @@ final class OpenAITestsCombine: XCTestCase {
         let query = CompletionsQuery(model: .textDavinci_003, prompt: "What is 42?", temperature: 0, maxTokens: 100, topP: 1, frequencyPenalty: 0, presencePenalty: 0, stop: ["\\n"])
         let expectedResult = CompletionsResult(id: "foo", object: "bar", created: 100500, model: .babbage, choices: [
             .init(text: "42 is the answer to everything", index: 0)
-        ])
+        ], usage: .init(promptTokens: 10, completionTokens: 10, totalTokens: 20))
         try self.stub(result: expectedResult)
         
         let result = try awaitPublisher(self.openAI.completions(query: query))
@@ -57,7 +57,7 @@ final class OpenAITestsCombine: XCTestCase {
             .init(object: "id-sdasd", embedding: [0.1, 0.2, 0.3, 0.4], index: 0),
             .init(object: "id-sdasd1", embedding: [0.4, 0.1, 0.7, 0.1], index: 1),
             .init(object: "id-sdasd2", embedding: [0.8, 0.1, 0.2, 0.8], index: 2)
-        ])
+        ], usage: .init(promptTokens: 10, totalTokens: 10))
         try self.stub(result: embeddingsResult)
         
         let result = try awaitPublisher(openAI.embeddings(query: query))


### PR DESCRIPTION
## What

`Usage` structure has been added to completions and embedding results.
Closes #36 

## Why

This is useful to count token usage. 

## Affected Areas

* Completions result
* Embeddings result
