### PR TITLE
ModelResult typo fix along with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ___
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FMacPaw%2FOpenAI%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/MacPaw/OpenAI)
 [![Twitter](https://img.shields.io/static/v1?label=Twitter&message=@MacPaw&color=CA1F67)](https://twitter.com/MacPaw)
 
-This repositorty contains Swift implementation over [OpenAI](https://beta.openai.com/docs/api-reference/) public API.
+This repository contains Swift implementation over [OpenAI](https://beta.openai.com/docs/api-reference/) public API.
 
 - [What is OpenAI](#what-is-openai)
 - [Installation](#installation)

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -68,7 +68,7 @@ final public class OpenAI: OpenAIProtocol {
     }
     
     public func model(query: ModelQuery, completion: @escaping (Result<ModelResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<ModelsResult>(body: query, url: buildURL(path: .models.withPath(query.model))), completion: completion)
+        performRequest(request: JSONRequest<ModelResult>(body: query, url: buildURL(path: .models.withPath(query.model))), completion: completion)
     }
     
     public func models(query: ModelsQuery, completion: @escaping (Result<ModelsResult, Error>) -> Void) {

--- a/Sources/OpenAI/Private/MultipartFormDataBodyBuilder.swift
+++ b/Sources/OpenAI/Private/MultipartFormDataBodyBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  MutlipartFormDataBodyBuilder.swift
+//  MultipartFormDataBodyBuilder.swift
 //  
 //
 //  Created by Sergii Kryvoblotskyi on 02/04/2023.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class MutlipartFormDataBodyBuilder {
+final class MultipartFormDataBodyBuilder {
         
     let boundary: String
     let entries: [MultipartFormDataEntry]
@@ -50,10 +50,10 @@ private extension MultipartFormDataEntry {
 
 private extension Data {
     
-  mutating func append(_ string: String) {
-    let data = string.data(
-        using: String.Encoding.utf8,
-        allowLossyConversion: true)
-    append(data!)
-  }
+    mutating func append(_ string: String) {
+        let data = string.data(
+            using: String.Encoding.utf8,
+            allowLossyConversion: true)
+        append(data!)
+    }
 }

--- a/Sources/OpenAI/Public/Models/AudioTranscriptionQuery.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranscriptionQuery.swift
@@ -30,7 +30,7 @@ public struct AudioTranscriptionQuery: Codable, Equatable {
 extension AudioTranscriptionQuery: MultipartFormDataBodyEncodable {
     
     func encode(boundary: String) -> Data {
-        let bodyBuilder = MutlipartFormDataBodyBuilder(boundary: boundary, entries: [
+        let bodyBuilder = MultipartFormDataBodyBuilder(boundary: boundary, entries: [
             .file(paramName: "file", fileName: fileName, fileData: file, contentType: "audio/mpeg"),
             .string(paramName: "model", value: model),
             .string(paramName: "prompt", value: prompt),

--- a/Sources/OpenAI/Public/Models/AudioTranslationQuery.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranslationQuery.swift
@@ -28,7 +28,7 @@ public struct AudioTranslationQuery: Codable, Equatable {
 extension AudioTranslationQuery: MultipartFormDataBodyEncodable {
     
     func encode(boundary: String) -> Data {
-        let bodyBuilder = MutlipartFormDataBodyBuilder(boundary: boundary, entries: [
+        let bodyBuilder = MultipartFormDataBodyBuilder(boundary: boundary, entries: [
             .file(paramName: "file", fileName: fileName, fileData: file, contentType: "audio/mpeg"),
             .string(paramName: "model", value: model),
             .string(paramName: "prompt", value: prompt),

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -151,7 +151,7 @@ class OpenAITests: XCTestCase {
         XCTAssertEqual(inError, apiError)
     }
     
-    func testAudioTransriptions() async throws {
+    func testAudioTranscriptions() async throws {
         let data = Data()
         let query = AudioTranscriptionQuery(file: data, fileName: "audio.m4a", model: .whisper_1)
         let transcriptionResult = AudioTranscriptionResult(text: "Hello, world!")
@@ -205,7 +205,7 @@ class OpenAITests: XCTestCase {
         XCTAssertEqual(similarity, 0.9510201910206734, accuracy: 0.000001)
     }
     
-    func testJSONReqestCreation() throws {
+    func testJSONRequestCreation() throws {
         let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", timeoutInterval: 14)
         let completionQuery = CompletionsQuery(model: .whisper_1, prompt: "how are you?")
         let jsonRequest = JSONRequest<CompletionsResult>(body: completionQuery, url: URL(string: "http://google.com")!)
@@ -217,7 +217,7 @@ class OpenAITests: XCTestCase {
         XCTAssertEqual(urlRequest.timeoutInterval, configuration.timeoutInterval)
     }
     
-    func testMultipartReqestCreation() throws {
+    func testMultipartRequestCreation() throws {
         let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", timeoutInterval: 14)
         let completionQuery = AudioTranslationQuery(file: Data(), fileName: "foo", model: .whisper_1)
         let jsonRequest = MultipartFormDataRequest<CompletionsResult>(body: completionQuery, url: URL(string: "http://google.com")!)

--- a/Tests/OpenAITests/OpenAITestsCombine.swift
+++ b/Tests/OpenAITests/OpenAITestsCombine.swift
@@ -82,7 +82,7 @@ final class OpenAITestsCombine: XCTestCase {
         XCTAssertEqual(result, listModelsResult)
     }
     
-    func testAudioTransriptions() throws {
+    func testAudioTranscriptions() throws {
         let data = Data()
         let query = AudioTranscriptionQuery(file: data, fileName: "audio.m4a", model: .whisper_1)
         let transcriptionResult = AudioTranscriptionResult(text: "Hello, world!")


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

I was going through my previous Model PR merge and spotted ModelsResult was being used instead of ModelResult in just one instance, but then spotted other things, so hopefully a "typo fix" PR makes sense in that context! Let me know if not and I'll amend.

## What

• ModelResult instead of ModelsResult in one instance (knew there was something!)
• "repositorty" → "repository"
• "MutlipartFormDataBodyBuilder" → "MultipartFormDataBodyBuilder"
• `func append` indentation tweaked for consistency
• "transriptions" → "transcriptions"
• "reqest" → "request"

## Why

Should help with consistency and readability.

## Affected Areas

Readme, OpenAI.swift, Audio, Tests.
