### PR TITLE
Add support for the Edits API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository contains Swift implementation over [OpenAI](https://platform.ope
     - [Audio](#audio)
         - [Audio Transcriptions](#audio-transcriptions)
         - [Audio Translations](#audio-translations)
+    - [Edits](#edits)
     - [Embeddings](#embeddings)
     - [Models](#models)
         - [List Models](#list-models)
@@ -388,6 +389,70 @@ let result = try await openAI.audioTranslations(query: query)
 
 Review [Audio Documentation](https://platform.openai.com/docs/api-reference/audio) for more info.
 
+### Edits
+
+Creates a new edit for the provided input, instruction, and parameters.
+
+**Request**
+
+```swift
+struct EditsQuery: Codable {
+    /// ID of the model to use.
+    public let model: Model
+    /// Input text to get embeddings for.
+    public let input: String?
+    /// The instruction that tells the model how to edit the prompt.
+    public let instruction: String
+    /// The number of images to generate. Must be between 1 and 10.
+    public let n: Int?
+    /// What sampling temperature to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
+    public let temperature: Double?
+    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+    public let topP: Double?
+}
+```
+
+**Response**
+
+```swift
+struct EditsResult: Codable, Equatable {
+    
+    public struct Choice: Codable, Equatable {
+        public let text: String
+        public let index: Int
+    }
+
+    public struct Usage: Codable, Equatable {
+        public let promptTokens: Int
+        public let completionTokens: Int
+        public let totalTokens: Int
+        
+        enum CodingKeys: String, CodingKey {
+            case promptTokens = "prompt_tokens"
+            case completionTokens = "completion_tokens"
+            case totalTokens = "total_tokens"
+        }
+    }
+    
+    public let object: String
+    public let created: TimeInterval
+    public let choices: [Choice]
+    public let usage: Usage
+}
+```
+
+**Example**
+
+```swift
+let query = EditsQuery(model: .gpt4, input: "What day of the wek is it?", instruction: "Fix the spelling mistakes")
+openAI.edits(query: query) { result in
+  //Handle response here
+}
+//or
+let result = try await openAI.edits(query: query)
+```
+
+Review [Edits Documentation](https://platform.openai.com/docs/api-reference/edits) for more info.
 
 ### Embeddings
 

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ struct EmbeddingsResult: Codable, Equatable {
 **Example**
 
 ```swift
-let query = EmbeddingsQuery(model: .textSearchBabbadgeDoc, input: "The food was delicious and the waiter...")
+let query = EmbeddingsQuery(model: .textSearchBabbageDoc, input: "The food was delicious and the waiter...")
 openAI.embeddings(query: query) { result in
   //Handle response here
 }
@@ -525,22 +525,37 @@ Models are represented as a typealias `typealias Model = String`.
 
 ```swift
 public extension Model {
-    static let textDavinci_003 = "text-davinci-003"
-    static let textDavinci_002 = "text-davinci-002"
-    static let textDavinci_001 = "text-davinci-001"
-    static let curie = "text-curie-001"
-    static let babbage = "text-babbage-001"
-    static let textSearchBabbadgeDoc = "text-search-babbage-doc-001"
-    static let textSearchBabbageQuery001 = "text-search-babbage-query-001"
-    static let ada = "text-ada-001"
-    static let textEmbeddingAda = "text-embedding-ada-002"
-    static let gpt3_5Turbo = "gpt-3.5-turbo"
-    static let gpt3_5Turbo0301 = "gpt-3.5-turbo-0301"
-    
     static let gpt4 = "gpt-4"
     static let gpt4_0314 = "gpt-4-0314"
     static let gpt4_32k = "gpt-4-32k"
     static let gpt4_32k_0314 = "gpt-4-32k-0314"
+    static let gpt3_5Turbo = "gpt-3.5-turbo"
+    static let gpt3_5Turbo0301 = "gpt-3.5-turbo-0301"
+    
+    static let textDavinci_003 = "text-davinci-003"
+    static let textDavinci_002 = "text-davinci-002"
+    static let textCurie = "text-curie-001"
+    static let textBabbage = "text-babbage-001"
+    static let textAda = "text-ada-001"
+    
+    static let textDavinci_001 = "text-davinci-001"
+    static let codeDavinciEdit_001 = "code-davinci-edit-001"
+    
+    static let whisper_1 = "whisper-1"
+    
+    static let davinci = "davinci"
+    static let curie = "curie"
+    static let babbage = "babbage"
+    static let ada = "ada"
+    
+    static let textEmbeddingAda = "text-embedding-ada-002"
+    static let textSearchAda = "text-search-ada-doc-001"
+    static let textSearchBabbageDoc = "text-search-babbage-doc-001"
+    static let textSearchBabbageQuery001 = "text-search-babbage-query-001"
+    
+    static let textModerationStable = "text-moderation-stable"
+    static let textModerationLatest = "text-moderation-latest"
+    static let moderation = "text-moderation-001"
 }
 ```
 

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -67,6 +67,10 @@ final public class OpenAI: OpenAIProtocol {
         performRequest(request: JSONRequest<ChatResult>(body: query, url: buildURL(path: .chats)), completion: completion)
     }
     
+    public func edits(query: EditsQuery, completion: @escaping (Result<EditsResult, Error>) -> Void) {
+        performRequest(request: JSONRequest<EditsResult>(body: query, url: buildURL(path: .edits)), completion: completion)
+    }
+    
     public func model(query: ModelQuery, completion: @escaping (Result<ModelResult, Error>) -> Void) {
         performRequest(request: JSONRequest<ModelResult>(body: query, url: buildURL(path: .models.withPath(query.model))), completion: completion)
     }
@@ -146,6 +150,7 @@ extension APIPath {
     static let images = "/v1/images/generations"
     static let embeddings = "/v1/embeddings"
     static let chats = "/v1/chat/completions"
+    static let edits = "/v1/edits"
     static let models = "/v1/models"
     static let moderations = "/v1/moderations"
     

--- a/Sources/OpenAI/Public/Models/AudioTranscriptionResult.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranscriptionResult.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  AudioTranscriptionResult.swift
 //  
 //
 //  Created by Sergii Kryvoblotskyi on 02/04/2023.

--- a/Sources/OpenAI/Public/Models/ChatQuery.swift
+++ b/Sources/OpenAI/Public/Models/ChatQuery.swift
@@ -78,5 +78,4 @@ public struct ChatQuery: Codable {
         self.logitBias = logitBias
         self.user = user
     }
-    
 }

--- a/Sources/OpenAI/Public/Models/ChatResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatResult.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ChatResult.swift
 //  
 //
 //  Created by Sergii Kryvoblotskyi on 02/04/2023.

--- a/Sources/OpenAI/Public/Models/EditsQuery.swift
+++ b/Sources/OpenAI/Public/Models/EditsQuery.swift
@@ -1,0 +1,32 @@
+//
+//  EditsQuery.swift
+//  
+//
+//  Created by Aled Samuel on 14/04/2023.
+//
+
+import Foundation
+
+public struct EditsQuery: Codable {
+    /// ID of the model to use.
+    public let model: Model
+    /// Input text to get embeddings for.
+    public let input: String?
+    /// The instruction that tells the model how to edit the prompt.
+    public let instruction: String
+    /// The number of images to generate. Must be between 1 and 10.
+    public let n: Int?
+    /// What sampling temperature to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
+    public let temperature: Double?
+    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+    public let topP: Double?
+    
+    public init(model: Model, input: String?, instruction: String, n: Int? = nil, temperature: Double? = nil, topP: Double? = nil) {
+        self.model = model
+        self.input = input
+        self.instruction = instruction
+        self.n = n
+        self.temperature = temperature
+        self.topP = topP
+    }
+}

--- a/Sources/OpenAI/Public/Models/EditsResult.swift
+++ b/Sources/OpenAI/Public/Models/EditsResult.swift
@@ -1,0 +1,33 @@
+//
+//  EditsResult.swift
+//  
+//
+//  Created by Aled Samuel on 14/04/2023.
+//
+
+import Foundation
+
+public struct EditsResult: Codable, Equatable {
+    
+    public struct Choice: Codable, Equatable {
+        public let text: String
+        public let index: Int
+    }
+
+    public struct Usage: Codable, Equatable {
+        public let promptTokens: Int
+        public let completionTokens: Int
+        public let totalTokens: Int
+        
+        enum CodingKeys: String, CodingKey {
+            case promptTokens = "prompt_tokens"
+            case completionTokens = "completion_tokens"
+            case totalTokens = "total_tokens"
+        }
+    }
+    
+    public let object: String
+    public let created: TimeInterval
+    public let choices: [Choice]
+    public let usage: Usage
+}

--- a/Sources/OpenAI/Public/Models/EmbeddingsQuery.swift
+++ b/Sources/OpenAI/Public/Models/EmbeddingsQuery.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  EmbeddingsQuery.swift
 //  
 //
 //  Created by Sergii Kryvoblotskyi on 02/04/2023.

--- a/Sources/OpenAI/Public/Models/Models/Models.swift
+++ b/Sources/OpenAI/Public/Models/Models/Models.swift
@@ -9,23 +9,67 @@ import Foundation
 
 public typealias Model = String
 public extension Model {
-    static let textDavinci_003 = "text-davinci-003"
-    static let textDavinci_002 = "text-davinci-002"
-    static let textDavinci_001 = "text-davinci-001"
-    static let curie = "text-curie-001"
-    static let babbage = "text-babbage-001"
-    static let textSearchBabbadgeDoc = "text-search-babbage-doc-001"
-    static let textSearchBabbageQuery001 = "text-search-babbage-query-001"
-    static let ada = "text-ada-001"
-    static let textEmbeddingAda = "text-embedding-ada-002"
-    static let moderation = "text-moderation-001"
+    
+    // Chat Completions
+    
+    /// More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat. Will be updated with our latest model iteration.
+    static let gpt4 = "gpt-4"
+    /// Snapshot of gpt-4 from March 14th 2023. Unlike gpt-4, this model will not receive updates, and will only be supported for a three month period ending on June 14th 2023.
+    static let gpt4_0314 = "gpt-4-0314"
+    /// Same capabilities as the base gpt-4 mode but with 4x the context length. Will be updated with our latest model iteration.
+    static let gpt4_32k = "gpt-4-32k"
+    /// Snapshot of gpt-4-32 from March 14th 2023. Unlike gpt-4-32k, this model will not receive updates, and will only be supported for a three month period ending on June 14th 2023.
+    static let gpt4_32k_0314 = "gpt-4-32k-0314"
+    /// Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003. Will be updated with our latest model iteration.
     static let gpt3_5Turbo = "gpt-3.5-turbo"
+    /// Snapshot of gpt-3.5-turbo from March 1st 2023. Unlike gpt-3.5-turbo, this model will not receive updates, and will only be supported for a three month period ending on June 1st 2023.
     static let gpt3_5Turbo0301 = "gpt-3.5-turbo-0301"
     
-    static let gpt4 = "gpt-4"
-    static let gpt4_0314 = "gpt-4-0314"
-    static let gpt4_32k = "gpt-4-32k"
-    static let gpt4_32k_0314 = "gpt-4-32k-0314"
+    // Completions
+    
+    /// Can do any language task with better quality, longer output, and consistent instruction-following than the curie, babbage, or ada models. Also supports inserting completions within text.
+    static let textDavinci_003 = "text-davinci-003"
+    /// Similar capabilities to text-davinci-003 but trained with supervised fine-tuning instead of reinforcement learning.
+    static let textDavinci_002 = "text-davinci-002"
+    /// Very capable, faster and lower cost than Davinci.
+    static let textCurie = "text-curie-001"
+    /// Capable of straightforward tasks, very fast, and lower cost.
+    static let textBabbage = "text-babbage-001"
+    /// Capable of very simple tasks, usually the fastest model in the GPT-3 series, and lowest cost.
+    static let textAda = "text-ada-001"
+    
+    // Edits
+    
+    static let textDavinci_001 = "text-davinci-001"
+    static let codeDavinciEdit_001 = "code-davinci-edit-001"
+    
+    // Transcriptions / Translations
     
     static let whisper_1 = "whisper-1"
+    
+    // Fine Tunes
+    
+    /// Most capable GPT-3 model. Can do any task the other models can do, often with higher quality.
+    static let davinci = "davinci"
+    /// Very capable, but faster and lower cost than Davinci.
+    static let curie = "curie"
+    /// Capable of straightforward tasks, very fast, and lower cost.
+    static let babbage = "babbage"
+    /// Capable of very simple tasks, usually the fastest model in the GPT-3 series, and lowest cost.
+    static let ada = "ada"
+    
+    // Embeddings
+    
+    static let textEmbeddingAda = "text-embedding-ada-002"
+    static let textSearchAda = "text-search-ada-doc-001"
+    static let textSearchBabbageDoc = "text-search-babbage-doc-001"
+    static let textSearchBabbageQuery001 = "text-search-babbage-query-001"
+    
+    // Moderations
+    
+    /// Almost as capable as the latest model, but slightly older.
+    static let textModerationStable = "text-moderation-stable"
+    /// Most capable moderation model. Accuracy will be slighlty higher than the stable model.
+    static let textModerationLatest = "text-moderation-latest"
+    static let moderation = "text-moderation-001"
 }

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -72,6 +72,21 @@ public extension OpenAIProtocol {
         }
     }
     
+    func edits(
+        query: EditsQuery
+    ) async throws -> EditsResult {
+        try await withCheckedThrowingContinuation { continuation in
+            edits(query: query) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+    
     func model(
         query: ModelQuery
     ) async throws -> ModelResult {

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
@@ -43,6 +43,13 @@ public extension OpenAIProtocol {
         .eraseToAnyPublisher()
     }
     
+    func edits(query: EditsQuery) -> AnyPublisher<EditsResult, Error> {
+        Future<EditsResult, Error> {
+            edits(query: query, completion: $0)
+        }
+        .eraseToAnyPublisher()
+    }
+    
     func model(query: ModelQuery) -> AnyPublisher<ModelResult, Error> {
         Future<ModelResult, Error> {
             model(query: query, completion: $0)

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -78,6 +78,23 @@ public protocol OpenAIProtocol {
     func chats(query: ChatQuery, completion: @escaping (Result<ChatResult, Error>) -> Void)
     
     /**
+     This function sends an edits query to the OpenAI API and retrieves an edited version of the prompt based on the instruction given.
+     
+     Example:
+     ```
+     let query = EditsQuery(model: .gpt4, input: "What day of the wek is it?", instruction: "Fix the spelling mistakes")
+     openAI.edits(query: query) { result in
+       //Handle response here
+     }
+     ```
+
+     - Parameters:
+       - query: An `EditsQuery` object containing the input parameters for the API request. This includes the input to be edited, the instruction specifying how it should be edited, and other settings.
+       - completion: A closure which receives the result when the API request finishes. The closure's parameter, `Result<EditsResult, Error>`, will contain either the `EditsResult` object with the model's response to the queried edit, or an error if the request failed.
+    **/
+    func edits(query: EditsQuery, completion: @escaping (Result<EditsResult, Error>) -> Void)
+    
+    /**
      This function sends a model query to the OpenAI API and retrieves a model instance, providing owner information. The Models API in this usage enables you to gather detailed information on the model in question, like GPT-3.
      
      Example:

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -48,7 +48,7 @@ public protocol OpenAIProtocol {
 
      Example:
      ```
-     let query = EmbeddingsQuery(model: .textSearchBabbadgeDoc, input: "The food was delicious and the waiter...")
+     let query = EmbeddingsQuery(model: .textSearchBabbageDoc, input: "The food was delicious and the waiter...")
      openAI.embeddings(query: query) { result in
        //Handle response here
      }

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -111,7 +111,7 @@ class OpenAITests: XCTestCase {
     }
     
     func testEmbeddings() async throws {
-        let query = EmbeddingsQuery(model: .textSearchBabbadgeDoc, input: "The food was delicious and the waiter...")
+        let query = EmbeddingsQuery(model: .textSearchBabbageDoc, input: "The food was delicious and the waiter...")
         let embeddingsResult = EmbeddingsResult(data: [
             .init(object: "id-sdasd", embedding: [0.1, 0.2, 0.3, 0.4], index: 0),
             .init(object: "id-sdasd1", embedding: [0.4, 0.1, 0.7, 0.1], index: 1),
@@ -124,7 +124,7 @@ class OpenAITests: XCTestCase {
     }
     
     func testEmbeddingsError() async throws {
-        let query = EmbeddingsQuery(model: .textSearchBabbadgeDoc, input: "The food was delicious and the waiter...")
+        let query = EmbeddingsQuery(model: .textSearchBabbageDoc, input: "The food was delicious and the waiter...")
         let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
         self.stub(error: inError)
 

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -90,6 +90,26 @@ class OpenAITests: XCTestCase {
         XCTAssertEqual(inError, apiError)
     }
     
+    func testEdits() async throws {
+        let query = EditsQuery(model: .gpt4, input: "What day of the wek is it?", instruction: "Fix the spelling mistakes")
+        let editsResult = EditsResult(object: "edit", created: 1589478378, choices: [
+            .init(text: "What day of the week is it?", index: 0)
+        ], usage: .init(promptTokens: 25, completionTokens: 32, totalTokens: 57))
+        try self.stub(result: editsResult)
+        
+        let result = try await openAI.edits(query: query)
+        XCTAssertEqual(result, editsResult)
+    }
+    
+    func testEditsError() async throws {
+        let query = EditsQuery(model: .gpt4, input: "What day of the wek is it?", instruction: "Fix the spelling mistakes")
+        let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
+        self.stub(error: inError)
+
+        let apiError: APIError = try await XCTExpectError { try await openAI.edits(query: query) }
+        XCTAssertEqual(inError, apiError)
+    }
+    
     func testEmbeddings() async throws {
         let query = EmbeddingsQuery(model: .textSearchBabbadgeDoc, input: "The food was delicious and the waiter...")
         let embeddingsResult = EmbeddingsResult(data: [

--- a/Tests/OpenAITests/OpenAITestsCombine.swift
+++ b/Tests/OpenAITests/OpenAITestsCombine.swift
@@ -62,7 +62,7 @@ final class OpenAITestsCombine: XCTestCase {
     }
     
     func testEmbeddings() throws {
-        let query = EmbeddingsQuery(model: .textSearchBabbadgeDoc, input: "The food was delicious and the waiter...")
+        let query = EmbeddingsQuery(model: .textSearchBabbageDoc, input: "The food was delicious and the waiter...")
         let embeddingsResult = EmbeddingsResult(data: [
             .init(object: "id-sdasd", embedding: [0.1, 0.2, 0.3, 0.4], index: 0),
             .init(object: "id-sdasd1", embedding: [0.4, 0.1, 0.7, 0.1], index: 1),

--- a/Tests/OpenAITests/OpenAITestsCombine.swift
+++ b/Tests/OpenAITests/OpenAITestsCombine.swift
@@ -51,6 +51,16 @@ final class OpenAITestsCombine: XCTestCase {
        XCTAssertEqual(result, chatResult)
     }
     
+    func testEdits() throws {
+        let query = EditsQuery(model: .gpt4, input: "What day of the wek is it?", instruction: "Fix the spelling mistakes")
+        let editsResult = EditsResult(object: "edit", created: 1589478378, choices: [
+            .init(text: "What day of the week is it?", index: 0)
+        ], usage: .init(promptTokens: 25, completionTokens: 32, totalTokens: 57))
+        try self.stub(result: editsResult)
+        let result = try awaitPublisher(openAI.edits(query: query))
+        XCTAssertEqual(result, editsResult)
+    }
+    
     func testEmbeddings() throws {
         let query = EmbeddingsQuery(model: .textSearchBabbadgeDoc, input: "The food was delicious and the waiter...")
         let embeddingsResult = EmbeddingsResult(data: [

--- a/Tests/OpenAITests/OpenAITestsDecoder.swift
+++ b/Tests/OpenAITests/OpenAITestsDecoder.swift
@@ -103,6 +103,31 @@ class OpenAITestsDecoder: XCTestCase {
         try decode(data, expectedValue)
     }
     
+    func testEdits() async throws {
+        let data = """
+        {
+          "object": "edit",
+          "created": 1589478378,
+          "choices": [
+            {
+              "text": "What day of the week is it?",
+              "index": 0,
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 25,
+            "completion_tokens": 32,
+            "total_tokens": 57
+          }
+        }
+        """
+        
+        let expectedValue = EditsResult(object: "edit", created: 1589478378, choices: [
+            .init(text: "What day of the week is it?", index: 0)
+        ], usage: .init(promptTokens: 25, completionTokens: 32, totalTokens: 57))
+        try decode(data, expectedValue)
+    }
+    
     func testEmbeddings() async throws {
         let data = """
         {


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

• Add "/v1/edits" endpoint
• Some incorrect "File.swift" naming fixes
• "Edits" related tests

## Why

Feature request #48 

## Affected Areas

Enhancement only.

## Notes

• May not need its own version of Choice and Usage structs in EditsResult.
• EditsQuery input may be able to default to "" but OpenAI docs unclear (made it optional, but no default value in init).