### PR TITLE
#50 Make a few session-related types and initializers public

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -45,10 +45,14 @@ final public class OpenAI: OpenAIProtocol {
     public convenience init(configuration: Configuration) {
         self.init(configuration: configuration, session: URLSession.shared)
     }
-    
-    init(configuration: Configuration, session: URLSessionProtocol = URLSession.shared) {
+
+    init(configuration: Configuration, session: URLSessionProtocol) {
         self.configuration = configuration
         self.session = session
+    }
+
+    public convenience init(configuration: Configuration, session: URLSession = URLSession.shared) {
+        self.init(configuration: configuration, session: session as URLSessionProtocol)
     }
     
     public func completions(query: CompletionsQuery, completion: @escaping (Result<CompletionsResult, Error>) -> Void) {


### PR DESCRIPTION
## What

Making a few session related properties, initializers and types public, so that #50 people can inject `URLSession`.

## Why

See ticket #50.

## Affected Areas

- API should be backward compatible.
