### PR TITLE
Add missing public init to ModelsQuery and ModelQuery

### DIFF
--- a/Sources/OpenAI/Public/Models/Models/ModelQuery.swift
+++ b/Sources/OpenAI/Public/Models/Models/ModelQuery.swift
@@ -10,4 +10,8 @@ import Foundation
 public struct ModelQuery: Codable, Equatable {
     /// The ID of the model to use for this request.
     public let model: Model
+
+    public init(model: Model) {
+        self.model = model
+    }
 }

--- a/Sources/OpenAI/Public/Models/Models/ModelsQuery.swift
+++ b/Sources/OpenAI/Public/Models/Models/ModelsQuery.swift
@@ -7,4 +7,6 @@
 
 import Foundation
 
-public struct ModelsQuery: Codable, Equatable { }
+public struct ModelsQuery: Codable, Equatable {
+    public init() { }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Add missing public initializers to `ModelsQuery` and `ModelQuery`.

## Why

Previously, there were no public initializers of `ModelsQuery` and `ModelQuery`. So, users of this library cannot use `models()` and `model()`.

```swift
let openAI = OpenAI(apiToken: "...")
let query = ModelsQuery() // Missing argument for parameter 'from' in call
try await openAI.models(query: query)
```

## Affected Areas

Now, we can use `models()` and `model()` properly.