### PR TITLE
Add Create Image example to Demo app

### DIFF
--- a/Demo/App/APIProvidedView.swift
+++ b/Demo/App/APIProvidedView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct APIProvidedView: View {
     @Binding var apiKey: String
     @StateObject var chatStore: ChatStore
+    @StateObject var imageStore: ImageStore
     @StateObject var miscStore: MiscStore
     @State var isShowingAPIConfigModal: Bool = true
 
@@ -29,6 +30,11 @@ struct APIProvidedView: View {
                 idProvider: idProvider
             )
         )
+        self._imageStore = StateObject(
+            wrappedValue: ImageStore(
+                openAIClient: OpenAI(apiToken: apiKey.wrappedValue)
+            )
+        )
         self._miscStore = StateObject(
             wrappedValue: MiscStore(
                 openAIClient: OpenAI(apiToken: apiKey.wrappedValue)
@@ -39,6 +45,7 @@ struct APIProvidedView: View {
     var body: some View {
         ContentView(
             chatStore: chatStore,
+            imageStore: imageStore,
             miscStore: miscStore
         )
         .onChange(of: apiKey) { newApiKey in

--- a/Demo/App/ContentView.swift
+++ b/Demo/App/ContentView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct ContentView: View {
     @ObservedObject var chatStore: ChatStore
+    @ObservedObject var imageStore: ImageStore
     @ObservedObject var miscStore: MiscStore
     @State private var selectedTab = 0
     @Environment(\.idProviderValue) var idProvider
@@ -33,6 +34,7 @@ struct ContentView: View {
             .tag(1)
 
             ImageView(
+                store: imageStore
             )
             .tabItem {
                 Label("Image", systemImage: "photo")
@@ -60,13 +62,6 @@ struct ChatsView: View {
 struct TranscribeView: View {
     var body: some View {
         Text("Transcribe: TBD")
-            .font(.largeTitle)
-    }
-}
-
-struct ImageView: View {
-    var body: some View {
-        Text("Image: TBD")
             .font(.largeTitle)
     }
 }

--- a/Demo/DemoChat/Sources/ImageStore.swift
+++ b/Demo/DemoChat/Sources/ImageStore.swift
@@ -1,0 +1,33 @@
+//
+//  ImageStore.swift
+//  DemoChat
+//
+//  Created by Aled Samuel on 24/04/2023.
+//
+
+import Foundation
+import OpenAI
+
+public final class ImageStore: ObservableObject {
+    public var openAIClient: OpenAIProtocol
+    
+    @Published var images: [ImagesResult.URLResult] = []
+    
+    public init(
+        openAIClient: OpenAIProtocol
+    ) {
+        self.openAIClient = openAIClient
+    }
+    
+    @MainActor
+    func images(query: ImagesQuery) async {
+        images.removeAll()
+        do {
+            let response = try await openAIClient.images(query: query)
+            images = response.data
+        } catch {
+            // TODO: Better error handling
+            print(error.localizedDescription)
+        }
+    }
+}

--- a/Demo/DemoChat/Sources/UI/Images/ImageCreationView.swift
+++ b/Demo/DemoChat/Sources/UI/Images/ImageCreationView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import OpenAI
-import SafariServices
 
 public struct ImageCreationView: View {
     @ObservedObject var store: ImageStore
@@ -15,7 +14,6 @@ public struct ImageCreationView: View {
     @State private var prompt: String = ""
     @State private var n: Int = 1
     @State private var size: String
-    @State private var showSafari = false
     
     private var sizes = ["256x256", "512x512", "1024x1024"]
     
@@ -61,14 +59,8 @@ public struct ImageCreationView: View {
                     ForEach($store.images, id: \.self) { image in
                         let urlString = image.wrappedValue.url
                         if let imageURL = URL(string: urlString), UIApplication.shared.canOpenURL(imageURL) {
-                            Button {
-                                showSafari.toggle()
-                            } label: {
-                                Text(urlString)
-                                    .foregroundStyle(.foreground)
-                            }.fullScreenCover(isPresented: $showSafari, content: {
-                                SafariView(url: imageURL)
-                            })
+                            LinkPreview(previewURL: imageURL)
+                                .aspectRatio(contentMode: .fit)
                         } else {
                             Text(urlString)
                                 .foregroundStyle(.secondary)
@@ -80,14 +72,4 @@ public struct ImageCreationView: View {
         .listStyle(.insetGrouped)
         .navigationTitle("Create Image")
     }
-}
-
-private struct SafariView: UIViewControllerRepresentable {
-    var url: URL
-    
-    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
-        SFSafariViewController(url: url)
-    }
-    
-    func updateUIViewController(_ safariViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) { }
 }

--- a/Demo/DemoChat/Sources/UI/Images/ImageCreationView.swift
+++ b/Demo/DemoChat/Sources/UI/Images/ImageCreationView.swift
@@ -1,0 +1,93 @@
+//
+//  ImageCreationView.swift
+//  DemoChat
+//
+//  Created by Aled Samuel on 24/04/2023.
+//
+
+import SwiftUI
+import OpenAI
+import SafariServices
+
+public struct ImageCreationView: View {
+    @ObservedObject var store: ImageStore
+    
+    @State private var prompt: String = ""
+    @State private var n: Int = 1
+    @State private var size: String
+    @State private var showSafari = false
+    
+    private var sizes = ["256x256", "512x512", "1024x1024"]
+    
+    public init(store: ImageStore) {
+        self.store = store
+        size = sizes[0]
+    }
+    
+    public var body: some View {
+        List {
+            Section {
+                HStack {
+                    Text("Prompt")
+                    Spacer()
+                    TextEditor(text: $prompt)
+                        .multilineTextAlignment(.trailing)
+                }
+                HStack {
+                    Stepper("Amount: \(n)", value: $n, in: 1...10)
+                }
+                HStack {
+                    Picker("Size", selection: $size) {
+                        ForEach(sizes, id: \.self) {
+                            Text($0)
+                        }
+                    }
+                }
+            }
+            Section {
+                HStack {
+                    Button("Create Image" + (n == 1 ? "" : "s")) {
+                        Task {
+                            let query = ImagesQuery(prompt: prompt, n: n, size: size)
+                            await store.images(query: query)
+                        }
+                    }
+                    .foregroundColor(.accentColor)
+                    Spacer()
+                }
+            }
+            if !$store.images.isEmpty {
+                Section("Images") {
+                    ForEach($store.images, id: \.self) { image in
+                        let urlString = image.wrappedValue.url
+                        if let imageURL = URL(string: urlString), UIApplication.shared.canOpenURL(imageURL) {
+                            Button {
+                                showSafari.toggle()
+                            } label: {
+                                Text(urlString)
+                                    .foregroundStyle(.foreground)
+                            }.fullScreenCover(isPresented: $showSafari, content: {
+                                SafariView(url: imageURL)
+                            })
+                        } else {
+                            Text(urlString)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Create Image")
+    }
+}
+
+private struct SafariView: UIViewControllerRepresentable {
+    var url: URL
+    
+    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+    
+    func updateUIViewController(_ safariViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) { }
+}

--- a/Demo/DemoChat/Sources/UI/Images/ImageView.swift
+++ b/Demo/DemoChat/Sources/UI/Images/ImageView.swift
@@ -1,0 +1,63 @@
+//
+//  ImageView.swift
+//  DemoChat
+//
+//  Created by Aled Samuel on 24/04/2023.
+//
+
+import SwiftUI
+
+public struct ImageView: View {
+    @ObservedObject var store: ImageStore
+    
+    public init(store: ImageStore) {
+        self.store = store
+    }
+    
+    public var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink("Create Image", destination: ImageCreationView(store: store))
+                NavigationLink("Create Image Edit", destination: ImageEditView(store: store))
+                    .disabled(true)
+                NavigationLink("Create Image Variation", destination: ImageVariationView(store: store))
+                    .disabled(true)
+                
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Image")
+        }
+    }
+}
+
+public struct ImageEditView: View {
+    @ObservedObject var store: ImageStore
+    
+    public init(store: ImageStore) {
+        self.store = store
+    }
+    
+    public var body: some View {
+        List {
+            
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Create Image Edit")
+    }
+}
+
+public struct ImageVariationView: View {
+    @ObservedObject var store: ImageStore
+    
+    public init(store: ImageStore) {
+        self.store = store
+    }
+    
+    public var body: some View {
+        List {
+            
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Create Image Variation")
+    }
+}

--- a/Demo/DemoChat/Sources/UI/Images/LinkPreview.swift
+++ b/Demo/DemoChat/Sources/UI/Images/LinkPreview.swift
@@ -1,0 +1,33 @@
+//
+//  LinkPreview.swift
+//  DemoChat
+//
+//  Created by Aled Samuel on 25/04/2023.
+//
+
+import SwiftUI
+import LinkPresentation
+
+struct LinkPreview: UIViewRepresentable {
+    typealias UIViewType = LPLinkView
+    
+    var previewURL: URL
+    
+    func makeUIView(context: Context) -> LPLinkView {
+        LPLinkView(url: previewURL)
+    }
+    
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+        LPMetadataProvider().startFetchingMetadata(for: previewURL) { metadata, error in
+            if let error = error {
+                print(error.localizedDescription)
+                return
+            }
+            guard let metadata = metadata else {
+                print("Metadata missing for \(previewURL.absoluteString)")
+                return
+            }
+            uiView.metadata = metadata
+        }
+    }
+}

--- a/Sources/OpenAI/Public/Models/ImagesResult.swift
+++ b/Sources/OpenAI/Public/Models/ImagesResult.swift
@@ -15,3 +15,5 @@ public struct ImagesResult: Codable, Equatable {
     public let created: TimeInterval
     public let data: [URLResult]
 }
+
+extension ImagesResult.URLResult: Hashable { }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

• Added ImageStore, follows same structure as ChatStore and MiscStore
• Added ImageView which is a list of being able to Create Images (this PR), and upcoming Create Image Edit and Create Image Variation (disabled, placeholder views)
• Uses SafariViewController to display image URL's when tapped though not ideal as not SwiftUI friendly
• ImagesResult.URLResult conforms to Hashable so I could use it in a list – may be better to map the url strings instead

## Why

#49, most likely a popular feature

## Affected Areas

ContentView, ImagesResult.URLResult

Like my Models DemoApp example, needs better error messaging

More than happy to tweak, especially in favour of nicer SwiftUI usage 👌

Preview:
![Simulator Screenshot - iPhone 14 Pro - 2023-04-24 at 15 34 59 2](https://user-images.githubusercontent.com/1451896/234057159-f614cf81-36a1-41e0-b011-d86bc5a88a39.png)
![Simulator Screenshot - iPhone 14 Pro - 2023-04-24 at 17 21 54 2](https://user-images.githubusercontent.com/1451896/234057549-b9c5bf77-23a9-4888-82f9-9b06de0cfd54.png)
