### PR TITLE
Update to 0613 OpenAI models

### DIFF
--- a/Sources/OpenAI/Public/Models/Models/Models.swift
+++ b/Sources/OpenAI/Public/Models/Models/Models.swift
@@ -12,19 +12,31 @@ public extension Model {
     
     // Chat Completions
     
-    /// More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat. Will be updated with our latest model iteration.
+    /// More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat. Will be updated with our latest model iteration 2 weeks after it is released.
     static let gpt4 = "gpt-4"
     /// Snapshot of gpt-4 from March 14th 2023. Unlike gpt-4, this model will not receive updates, and will only be supported for a three month period ending on June 14th 2023.
+    @available(*, deprecated, message: "Please upgrade to the newer model")
     static let gpt4_0314 = "gpt-4-0314"
+    /// Snapshot of gpt-4 from June 13th 2023 with function calling data. Unlike gpt-4, this model will not receive updates, and will be deprecated 3 months after a new version is released.
+    static let gpt4_0613 = "gpt-4-0613"
     /// Same capabilities as the base gpt-4 mode but with 4x the context length. Will be updated with our latest model iteration.
     static let gpt4_32k = "gpt-4-32k"
     /// Snapshot of gpt-4-32 from March 14th 2023. Unlike gpt-4-32k, this model will not receive updates, and will only be supported for a three month period ending on June 14th 2023.
     static let gpt4_32k_0314 = "gpt-4-32k-0314"
+    /// Snapshot of gpt-4-32 from June 13th 2023. Unlike gpt-4-32k, this model will not receive updates, and will be deprecated 3 months after a new version is released.
+    static let gpt4_32k_0613 = "gpt-4-32k-0613"
     /// Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003. Will be updated with our latest model iteration.
     static let gpt3_5Turbo = "gpt-3.5-turbo"
     /// Snapshot of gpt-3.5-turbo from March 1st 2023. Unlike gpt-3.5-turbo, this model will not receive updates, and will only be supported for a three month period ending on June 1st 2023.
+    @available(*, deprecated, message: "Please upgrade to the newer model")
     static let gpt3_5Turbo0301 = "gpt-3.5-turbo-0301"
-    
+    /// Snapshot of gpt-3.5-turbo from June 13th 2023 with function calling data. Unlike gpt-3.5-turbo, this model will not receive updates, and will be deprecated 3 months after a new version is released.
+    static let gpt3_5Turbo0613 = "gpt-3.5-turbo-0613"
+    /// Same capabilities as the standard gpt-3.5-turbo model but with 4 times the context.
+    static let gpt3_5Turbo_16k = "gpt-3.5-turbo-16k"
+    /// Snapshot of gpt-3.5-turbo-16k from June 13th 2023. Unlike gpt-3.5-turbo-16k, this model will not receive updates, and will be deprecated 3 months after a new version is released.
+    static let gpt3_5Turbo_16k_0613 = "gpt-3.5-turbo-16k-0613"
+
     // Completions
     
     /// Can do any language task with better quality, longer output, and consistent instruction-following than the curie, babbage, or ada models. Also supports inserting completions within text.


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Adds new OpenAI chat models: *-0613 (June 13th) and GPT-3.5-turbo-16K also adds deprecation annotation to now outdated models.

## Why

OpenAI release new models yesterday, most notably 16k context for GPT-3.5, this PR adds model IDs for them.
https://platform.openai.com/docs/models/

## Affected Areas

Models.swift file