### PR TITLE
Add functionCall to ChatQuery

### DIFF
--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -76,7 +76,29 @@ class OpenAITests: XCTestCase {
         
        let result = try await openAI.chats(query: query)
        XCTAssertEqual(result, chatResult)
-   }
+    }
+
+    func testChatsFunction() async throws {
+        let query = ChatQuery(model: .gpt3_5Turbo0613, messages: [
+            .init(role: .system, content: "You are Weather-GPT. You know everything about the weather."),
+            .init(role: .user, content: "What's the weather like in Boston?"),
+        ], functions: [
+            .init(name: "get_current_weather", description: "Get the current weather in a given location", parameters: .init(type: .object, properties: [
+                "location": .init(type: .string, description: "The city and state, e.g. San Francisco, CA"),
+                "unit": .init(type: .string, enumValues: ["celsius", "fahrenheit"])
+            ], required: ["location"]))
+        ], functionCall: .auto)
+        
+        let chatResult = ChatResult(id: "id-12312", object: "foo", created: 100, model: .gpt3_5Turbo, choices: [
+         .init(index: 0, message: .init(role: .system, content: "bar"), finishReason: "baz"),
+         .init(index: 0, message: .init(role: .user, content: "bar1"), finishReason: "baz1"),
+         .init(index: 0, message: .init(role: .assistant, content: "bar2"), finishReason: "baz2")
+         ], usage: .init(promptTokens: 100, completionTokens: 200, totalTokens: 300))
+        try self.stub(result: chatResult)
+        
+        let result = try await openAI.chats(query: query)
+        XCTAssertEqual(result, chatResult)
+    }
     
     func testChatsError() async throws {
         let query = ChatQuery(model: .gpt4, messages: [


### PR DESCRIPTION
ChatQuery was  missing `functionCall` which can be used to force the usage of given function names. API docs can be found here: https://platform.openai.com/docs/api-reference/chat/create#chat/create-function_call

It's a bit of a weird value type so I had to do some custom encoding.