### PR TITLE
[BUG FIX] Encode content property with nil value when responding to function calling

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatQuery.swift
+++ b/Sources/OpenAI/Public/Models/ChatQuery.swift
@@ -35,6 +35,25 @@ public struct Chat: Codable, Equatable {
         self.name = name
         self.functionCall = functionCall
     }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(role, forKey: .role)
+
+        if let name = name {
+            try container.encode(name, forKey: .name)
+        }
+
+        if let functionCall = functionCall {
+            try container.encode(functionCall, forKey: .functionCall)
+        }
+
+        // Should add 'nil' to 'content' property for function calling response
+        // See https://openai.com/blog/function-calling-and-other-api-updates
+        if content != nil || (role == .assistant && functionCall != nil) {
+            try container.encode(content, forKey: .content)
+        }
+    }
 }
 
 public struct ChatFunctionCall: Codable, Equatable {


### PR DESCRIPTION
## What

Encode `content` property with `nil` value in `Chat` struct build `Chat` instance for responding to function calling result.

## Why

We must send two chat instances when sending function calling result to OpenAI.
Ref: `Function calling example` section of https://openai.com/blog/function-calling-and-other-api-updates

```
Chat(role: .assistant, content: nil, functionCall: functionCall),
Chat(role: .function, content: functionContent, name: functionName)
```

Most importantly, we must encode `content` property with `nil` value for the first one. But current encoder behavior removes `content` property if value is `nil` which is the default behavior of `JSONEncoder`.

Actually, if I send above messages to chat endpoint, then I get 400 error as follows because payload doesn't include `content` property.

```
{
  "error": {
    "message": "'content' is a required property - 'messages.1'",
    "type": "invalid_request_error",
    "param": null,
    "code": null
  }
}
```

Payload doesn't have `content` property actually because it is nil value.
`{"role":"assistant","function_call":{"name":"add","arguments":"{\"a\": \"1\", \"b\": \"1\"}"}}`

So I want to fix this behavior.

## Affected Areas

I modified encoding behavior of `Chat` struct not to remove `content` property even if it is nil but has `functionCall` value. by overriding `encode(to encoder:)` method. Other properties would be encoded same as originally which means it would be included if it has the value, otherwise, not.
