### PR TITLE
Fix issue where chatsStream() throws incorrect error

### DIFF
--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -62,12 +62,23 @@ final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSe
                 onProcessingError?(self, StreamingError.unknownContent)
                 return
             }
+            
+            var apiError: Error? = nil
             do {
                 let decoder = JSONDecoder()
                 let object = try decoder.decode(ResultType.self, from: jsonData)
                 onReceiveContent?(self, object)
             } catch {
-                onProcessingError?(self, error)
+                apiError = error
+            }
+            
+            if let apiError = apiError {
+                do {
+                    let decoded = try JSONDecoder().decode(APIErrorResponse.self, from: data)
+                    onProcessingError?(self, decoded)
+                } catch {
+                    onProcessingError?(self, apiError)
+                }
             }
         }
     }


### PR DESCRIPTION
## What

This PR fixes the regression bug where it throws incorrect error when streaming

Reference: https://github.com/MacPaw/OpenAI/pull/23

## Affected Areas

`OpenAI.chatsStream()`, `StreamingSession`
