### PR TITLE
Fix the issue where it does not decode the Error correctly when streaming response

### DIFF
--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -74,7 +74,7 @@ final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSe
             
             if let apiError = apiError {
                 do {
-                    let decoded = try JSONDecoder().decode(APIErrorResponse.self, from: data)
+                    let decoded = try JSONDecoder().decode(APIErrorResponse.self, from: jsonData)
                     onProcessingError?(self, decoded)
                 } catch {
                     onProcessingError?(self, apiError)


### PR DESCRIPTION
## What

When using streaming, there might be an error occurring in the middle of the streaming.

This PR fixes it.

Previous PR: https://github.com/MacPaw/OpenAI/pull/87

## Why

Related: https://github.com/MacPaw/OpenAI/issues/88

## Affected Areas

`StreamingSession.swift`
