### PR TITLE
APIErrorResponse message can be [String]. Handle it.

### DIFF
--- a/Sources/OpenAI/Public/Errors/APIError.swift
+++ b/Sources/OpenAI/Public/Errors/APIError.swift
@@ -16,6 +16,39 @@ public struct APIError: Error, Decodable, Equatable {
     public let type: String
     public let param: String?
     public let code: String?
+  
+  public init(message: String, type: String, param: String?, code: String?) {
+    self.message = message
+    self.type = type
+    self.param = param
+    self.code = code
+  }
+  
+  enum CodingKeys: CodingKey {
+    case message
+    case type
+    case param
+    case code
+  }
+  
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    //
+    // message can be String or [String].
+    //
+    if let string = try? container.decode(String.self, forKey: .message) {
+      self.message = string
+    } else if let array = try? container.decode([String].self, forKey: .message) {
+      self.message = array.joined(separator: "\n")
+    } else {
+      throw DecodingError.typeMismatch(String.self, .init(codingPath: [CodingKeys.message], debugDescription: "message: expected String or [String]"))
+    }
+    
+    self.type = try container.decode(String.self, forKey: .type)
+    self.param = try container.decodeIfPresent(String.self, forKey: .param)
+    self.code = try container.decodeIfPresent(String.self, forKey: .code)
+  }
 }
 
 extension APIError: LocalizedError {


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

The API error response message can be an array. Decode that to a String.

## Why

API errors where the response is [String] like for ChatGPT -> Functions misuse is not decoded and shown.

## Affected Areas

Error handling.
Not sure about streaming errors.
