### PR TITLE
Demo App: Added text chat input validation, enabling 'Send' button only for valid input.

### DIFF
--- a/Demo/DemoChat/Sources/UI/DetailView.swift
+++ b/Demo/DemoChat/Sources/UI/DetailView.swift
@@ -176,6 +176,7 @@ struct DetailView: View {
                     .frame(width: 24, height: 24)
                     .padding(.trailing)
             }
+            .disabled(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         .padding(.bottom)
     }
@@ -183,7 +184,12 @@ struct DetailView: View {
     private func tapSendMessage(
         scrollViewProxy: ScrollViewProxy
     ) {
-        sendMessage(inputText, selectedChatModel)
+        let message = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if message.isEmpty {
+            return
+        }
+        
+        sendMessage(message, selectedChatModel)
         inputText = ""
         
 //        if let lastMessage = conversation.messages.last {


### PR DESCRIPTION


<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Implemented chat input text validation in demo app packages. Now, when sending a message, any white spaces in the text input are automatically formatted. Additionally, the send button is disabled when there is no text input to prevent the creation of empty chat bubbles and unwanted responses.

## Why

issue #101 

## Affected Areas

Demo app: Text chats input area.
