### PR TITLE
Fix for broken Image demo 

### DIFF
--- a/Demo/App/APIProvidedView.swift
+++ b/Demo/App/APIProvidedView.swift
@@ -51,6 +51,7 @@ struct APIProvidedView: View {
         .onChange(of: apiKey) { newApiKey in
             let client = OpenAI(apiToken: newApiKey)
             chatStore.openAIClient = client
+            imageStore.openAIClient = client
             miscStore.openAIClient = client
         }
     }


### PR DESCRIPTION
## What

Add missing API key for image demo

## Why

The image demo gives invalid key error without this.

## Affected Areas

Demo App.
