### PR TITLE
feat: adds `quality` to `ImagesQuery`

### DIFF
--- a/Sources/OpenAI/Public/Models/ImagesQuery.swift
+++ b/Sources/OpenAI/Public/Models/ImagesQuery.swift
@@ -1,6 +1,6 @@
 //
 //  ImagesQuery.swift
-//  
+//
 //
 //  Created by Sergii Kryvoblotskyi on 02/04/2023.
 //
@@ -31,8 +31,10 @@ public struct ImagesQuery: Codable {
     public let user: String?
     /// The style of the generated images. Must be one of vivid or natural. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images. This param is only supported for dall-e-3.
     public let style: String?
-
-    public init(prompt: String, model: Model?=nil, responseFormat: Self.ResponseFormat?=nil, n: Int?, size: String?, style: String?=nil, user:String?=nil) {
+    /// The quality of the image that will be generated. hd creates images with finer details and greater consistency across the image. This param is only supported for dall-e-3.
+    public let quality: String?
+    
+    public init(prompt: String, model: Model?=nil, responseFormat: Self.ResponseFormat?=nil, n: Int?, size: String?, style: String?=nil, user:String?=nil, quality:String?=nil) {
         self.style = style
         self.prompt = prompt
         self.n = n
@@ -40,6 +42,7 @@ public struct ImagesQuery: Codable {
         self.model = model
         self.responseFormat = responseFormat
         self.user = user
+        self.quality = quality
     }
     
     public enum CodingKeys: String, CodingKey {
@@ -50,5 +53,6 @@ public struct ImagesQuery: Codable {
         case user
         case style
         case responseFormat = "response_format"
+        case quality
     }
 }


### PR DESCRIPTION
## What

Hi folks! This pull request introduces a new `quality` parameter to the `ImagesQuery`.

## Why

OpenAI now supports a high-definition (HD) quality option for DALL·E 3, as detailed in the [official documentation](https://platform.openai.com/docs/api-reference/images/create#images-create-quality).

## Affected Areas

I have changed the `ImageQuery` file to add a new `quality` parameter. I'm not sure if I need to change anything else. Please check and tell me if there's more to update for this new feature to work well.