### PR TITLE
trimming contentString

### DIFF
--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -57,7 +57,7 @@ final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSe
 extension StreamingSession {
     
     private func processJSON(from stringContent: String) {
-        let jsonObjects = "\(previousChunkBuffer)\(stringContent)"
+        let jsonObjects = "\(previousChunkBuffer)\(stringContent)".trimmingCharacters(in: .whitespacesAndNewlines)
             .components(separatedBy: "data:")
             .filter { $0.isEmpty == false }
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }


### PR DESCRIPTION
stringContent may contain a prefix new line ("\n") before the first "data:" separator.

## What

When query with chat streaming API, the response may contain a prefix new line (`\n`) before the first `data:` separator.

## Affected Areas

Chat Streaming APIs
