### PR TITLE
Fix: prevent json decoding error when streaming

### DIFF
--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -59,9 +59,9 @@ extension StreamingSession {
     private func processJSON(from stringContent: String) {
         let jsonObjects = "\(previousChunkBuffer)\(stringContent)"
             .components(separatedBy: "data:")
-            .filter { $0.isEmpty == false }
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        
+            .filter { $0.isEmpty == false }
+
         previousChunkBuffer = ""
         
         guard jsonObjects.isEmpty == false, jsonObjects.first != streamingCompletionMarker else {


### PR DESCRIPTION
## What

Filter empty json content after trimming whitespace instead of before

## Why

Addresses https://github.com/MacPaw/OpenAI/issues/128 and https://github.com/MacPaw/OpenAI/issues/153

## Affected Areas


--

Fix inspired by this comment https://github.com/MacPaw/OpenAI/pull/151#issuecomment-1913703132