### PR TITLE
array thread safety wrapper to fix racing condition causing Fatal error

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -35,7 +35,7 @@ final public class OpenAI: OpenAIProtocol {
     }
     
     private let session: URLSessionProtocol
-    private var streamingSessions: [NSObject] = []
+    private var streamingSessions = ArrayWithThreadSafety<NSObject>()
     
     public let configuration: Configuration
 

--- a/Sources/OpenAI/Public/Utilities/ArrayWithThreadSafety.swift
+++ b/Sources/OpenAI/Public/Utilities/ArrayWithThreadSafety.swift
@@ -1,0 +1,26 @@
+//
+//  ArrayWithThreadSafety.swift
+//
+//
+//  Created by James J Kalafus on 2024-02-01.
+//
+
+import Foundation
+
+internal class ArrayWithThreadSafety<Element> {
+    private var array = [Element]()
+    private let queue = DispatchQueue(label: "us.kalaf.OpenAI.threadSafeArray", attributes: .concurrent)
+
+    @inlinable public func append(_ element: Element) {
+        queue.async(flags: .barrier) {
+            self.array.append(element)
+        }
+    }
+
+    @inlinable public func removeAll(where shouldBeRemoved: @escaping (Element) throws -> Bool) rethrows {
+        try queue.sync(flags: .barrier) {
+            try self.array.removeAll(where: shouldBeRemoved)
+        }
+    }
+}
+


### PR DESCRIPTION
thread safe array wrapper to fix racing condition

## What

`Fatal error: UnsafeMutablePointer.moveUpdate(from:) with negative count` at `self?.streamingSessions.removeAll(where: { $0 == object })`

## Why

array can be concurrently accessed with append and removeAll methods.

## Affected Areas

networking
