### PR TITLE
PCM support for text-to-speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ public struct AudioSpeechQuery: Codable, Equatable {
 **Response:**
 
 ```swift
-/// Audio data for one of the following formats :`mp3`, `opus`, `aac`, `flac`
+/// Audio data for one of the following formats :`mp3`, `opus`, `aac`, `flac`, `pcm`
 public let audioData: Data?
 ```
 

--- a/Sources/OpenAI/Public/Models/AudioSpeechQuery.swift
+++ b/Sources/OpenAI/Public/Models/AudioSpeechQuery.swift
@@ -31,11 +31,13 @@ public struct AudioSpeechQuery: Codable {
     /// -  opus
     /// -  aac
     /// -  flac
+    /// -  pcm
     public enum AudioSpeechResponseFormat: String, Codable, CaseIterable {
         case mp3
         case opus
         case aac
         case flac
+        case pcm
     }
 
     /// The text to generate audio for. The maximum length is 4096 characters.
@@ -45,7 +47,7 @@ public struct AudioSpeechQuery: Codable {
     /// The voice to use when generating the audio. Supported voices are alloy, echo, fable, onyx, nova, and shimmer. Previews of the voices are available in the Text to speech guide.
     /// https://platform.openai.com/docs/guides/text-to-speech/voice-options
     public let voice: AudioSpeechVoice
-    /// The format to audio in. Supported formats are mp3, opus, aac, and flac.
+    /// The format to audio in. Supported formats are mp3, opus, aac, flac, and pcm.
     /// Defaults to mp3
     public let responseFormat: AudioSpeechResponseFormat?
     /// The speed of the generated audio. Select a value from **0.25** to **4.0**. **1.0** is the default.

--- a/Sources/OpenAI/Public/Models/AudioSpeechResult.swift
+++ b/Sources/OpenAI/Public/Models/AudioSpeechResult.swift
@@ -11,6 +11,6 @@ import Foundation
 /// Learn more: [OpenAI Speech – Documentation](https://platform.openai.com/docs/api-reference/audio/createSpeech)
 public struct AudioSpeechResult: Codable, Equatable {
 
-    /// Audio data for one of the following formats :`mp3`, `opus`, `aac`, `flac`
+    /// Audio data for one of the following formats :`mp3`, `opus`, `aac`, `flac`, `pcm`
     public let audio: Data
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

I'm not sure if it's a recent change but the API supports `pcm` for text-to-speech and it isn't supported by this library. A simple change to allow `pcm` as a format.

## Why

Bring up to spec with the API

## Affected Areas

Text-to-speech
