### PR TITLE
Chore: Add initializer for `FunctionCall`

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatQuery.swift
+++ b/Sources/OpenAI/Public/Models/ChatQuery.swift
@@ -502,6 +502,14 @@ public struct ChatQuery: Equatable, Codable, Streamable {
                     public let arguments: String
                     /// The name of the function to call.
                     public let name: String
+
+                    public init(
+                        arguments: String,
+                        name: String
+                    ) {
+                        self.arguments = arguments
+                        self.name = name
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What

Add a public initializer for `ChatQuery.ChatCompletionMessageParam.ChatCompletionAssistantMessageParam.ChatCompletionMessageToolCallParam.FunctionCall`, allowing it to be created programmatically.

## Why

When converting chat history from other LLM services (such as Claude and Gemini) into the OpenAI format, it is necessary to create instances of the FunctionCall struct programmatically. However, the initializer for the FunctionCall struct is currently missing, making it impossible to create instances of this struct from code outside the package. 

## Affected Areas

Only `ChatQuery.ChatCompletionMessageParam.ChatCompletionAssistantMessageParam.ChatCompletionMessageToolCallParam.FunctionCall`
