### PR TITLE
Add create audio speech stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,42 @@ let result = try await openAI.audioCreateSpeech(query: query)
 ```
 [OpenAI Create Speech – Documentation](https://platform.openai.com/docs/api-reference/audio/createSpeech)
 
+#### Audio Create Speech Streaming
+
+Audio Create Speech is available by using `audioCreateSpeechStream` function. Tokens will be sent one-by-one.
+
+**Closures**
+```swift
+openAI.audioCreateSpeechStream(query: query) { partialResult in
+    switch partialResult {
+    case .success(let result):
+        print(result.audio)
+    case .failure(let error):
+        //Handle chunk error here
+    }
+} completion: { error in
+    //Handle streaming error here
+}
+```
+
+**Combine**
+
+```swift
+openAI
+    .audioCreateSpeechStream(query: query)
+    .sink { completion in
+        //Handle completion result here
+    } receiveValue: { result in
+        //Handle chunk here
+    }.store(in: &cancellables)
+```
+
+**Structured concurrency**
+```swift
+for try await result in openAI.audioCreateSpeechStream(query: query) {
+   //Handle result here
+}
+```
 
 #### Audio Transcriptions
 

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -162,10 +162,10 @@ extension OpenAI {
                                             organizationIdentifier: configuration.organizationIdentifier,
                                             timeoutInterval: configuration.timeoutInterval)
             let session = StreamingSession<ResultType>(urlRequest: request)
-            session.onReceiveContent = {_, object in
+            session.onReceiveContent = { _, object in
                 onResult(.success(object))
             }
-            session.onProcessingError = {_, error in
+            session.onProcessingError = { _, error in
                 onResult(.failure(error))
             }
             session.onComplete = { [weak self] object, error in
@@ -207,10 +207,10 @@ extension OpenAI {
                                             organizationIdentifier: configuration.organizationIdentifier,
                                             timeoutInterval: configuration.timeoutInterval)
             let session = StreamingSession<AudioSpeechResult>(urlRequest: request)
-            session.onReceiveContent = {_, object in
+            session.onReceiveContent = { _, object in
                 onResult(.success(object))
             }
-            session.onProcessingError = {_, error in
+            session.onProcessingError = { _, error in
                 onResult(.failure(error))
             }
             session.onComplete = { [weak self] object, error in

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -120,7 +120,6 @@ final public class OpenAI: OpenAIProtocol {
         performSpeechRequest(request: JSONRequest<AudioSpeechResult>(body: query, url: buildURL(path: .audioSpeech)), completion: completion)
     }
 
-
     public func audioCreateSpeechStream(query: AudioSpeechQuery, onResult: @escaping (Result<AudioSpeechResult, Error>) -> Void, completion: ((Error?) -> Void)?) {
         performSpeechStreamingRequest(
             request: JSONRequest<AudioSpeechResult>(body: query, url: buildURL(path: .audioSpeech)),

--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -45,6 +45,10 @@ final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSe
     }
     
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        if ResultType.self == AudioSpeechResult.self, let result = AudioSpeechResult(audio: data) as? ResultType {
+            onReceiveContent?(self, result)
+            return
+        }
         guard let stringContent = String(data: data, encoding: .utf8) else {
             onProcessingError?(self, StreamingError.unknownContent)
             return

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -198,7 +198,19 @@ public extension OpenAIProtocol {
             }
         }
     }
-    
+
+    func audioCreateSpeechStream(
+        query: AudioSpeechQuery
+    ) -> AsyncThrowingStream<AudioSpeechResult, Error> {
+        return AsyncThrowingStream { continuation in
+            return audioCreateSpeechStream(query: query)  { result in
+                continuation.yield(with: result)
+            } completion: { error in
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+
     func audioTranscriptions(
         query: AudioTranscriptionQuery
     ) async throws -> AudioTranscriptionResult {

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -118,7 +118,7 @@ public extension OpenAIProtocol {
         query: ChatQuery
     ) -> AsyncThrowingStream<ChatStreamResult, Error> {
         return AsyncThrowingStream { continuation in
-            return chatsStream(query: query)  { result in
+            return chatsStream(query: query) { result in
                 continuation.yield(with: result)
             } completion: { error in
                 continuation.finish(throwing: error)
@@ -203,7 +203,7 @@ public extension OpenAIProtocol {
         query: AudioSpeechQuery
     ) -> AsyncThrowingStream<AudioSpeechResult, Error> {
         return AsyncThrowingStream { continuation in
-            return audioCreateSpeechStream(query: query)  { result in
+            return audioCreateSpeechStream(query: query) { result in
                 continuation.yield(with: result)
             } completion: { error in
                 continuation.finish(throwing: error)

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
@@ -70,7 +70,7 @@ public extension OpenAIProtocol {
         }
         .eraseToAnyPublisher()
     }
-    
+
     func chatsStream(query: ChatQuery) -> AnyPublisher<Result<ChatStreamResult, Error>, Error> {
         let progress = PassthroughSubject<Result<ChatStreamResult, Error>, Error>()
         chatsStream(query: query) { result in
@@ -84,7 +84,7 @@ public extension OpenAIProtocol {
         }
         return progress.eraseToAnyPublisher()
     }
-    
+
     func edits(query: EditsQuery) -> AnyPublisher<EditsResult, Error> {
         Future<EditsResult, Error> {
             edits(query: query, completion: $0)
@@ -118,6 +118,20 @@ public extension OpenAIProtocol {
             audioCreateSpeech(query: query, completion: $0)
         }
         .eraseToAnyPublisher()
+    }
+
+    func audioCreateSpeechStream(query: AudioSpeechQuery) -> AnyPublisher<Result<AudioSpeechResult, Error>, Error> {
+        let progress = PassthroughSubject<Result<AudioSpeechResult, Error>, Error>()
+        audioCreateSpeechStream(query: query) { result in
+            progress.send(result)
+        } completion: { error in
+            if let error {
+                progress.send(completion: .failure(error))
+            } else {
+                progress.send(completion: .finished)
+            }
+        }
+        return progress.eraseToAnyPublisher()
     }
 
     func audioTranscriptions(query: AudioTranscriptionQuery) -> AnyPublisher<AudioTranscriptionResult, Error> {

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -231,6 +231,21 @@ public protocol OpenAIProtocol {
      */
     func audioCreateSpeech(query: AudioSpeechQuery, completion: @escaping (Result<AudioSpeechResult, Error>) -> Void)
     
+    /** This function sends an `AudioSpeechQuery` to the OpenAI API to create audio speech from text using a specific voice and format.
+     Example:
+     ```
+     let query = AudioSpeechQuery(model: .tts_1, input: "Hello, world!", voice: .alloy, responseFormat: .mp3, speed: 1.0)
+     openAI.audioCreateSpeech(query: query) { result in
+        // Handle response here
+     }
+     ```
+     - Parameters:
+       - query: An `AudioSpeechQuery` object containing the parameters for the API request. This includes the Text-to-Speech model to be used, input text, voice to be used for generating the audio, the desired audio format, and the speed of the generated audio.
+       - onResult: A closure which receives the result when the API request finishes. The closure's parameter, `Result<AudioSpeechResult, Error>`, will contain either the `AudioSpeechResult` object with the generated Audio chunk, or an error if the request failed.
+       - completion: A closure that is being called when all chunks are delivered or uncrecoverable error occured
+    */
+    func audioCreateSpeechStream(query: AudioSpeechQuery, onResult: @escaping (Result<AudioSpeechResult, Error>) -> Void, completion: ((Error?) -> Void)?)
+
     /**
     Transcribes audio data using OpenAI's audio transcription API and completes the operation asynchronously.
 

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -235,7 +235,7 @@ public protocol OpenAIProtocol {
      Example:
      ```
      let query = AudioSpeechQuery(model: .tts_1, input: "Hello, world!", voice: .alloy, responseFormat: .mp3, speed: 1.0)
-     openAI.audioCreateSpeech(query: query) { result in
+     openAI.audioCreateSpeechStream(query: query) { result in
         // Handle response here
      }
      ```


### PR DESCRIPTION
## What

OpenAI supports sending audio speech by chunks (see my issue here: https://github.com/MacPaw/OpenAI/issues/185). This PR adds support for this feature.

## Why

With this change, clients can start audio playback with less latency, as far as first audio chunk will be received. 

## Affected Areas

In `OpenAIProtocol` was added new method `audioCreateSpeechStream`
