### PR TITLE
Add pathPrefix to Configuration

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -23,16 +23,18 @@ final public class OpenAI: OpenAIProtocol {
         /// API host. Set this property if you use some kind of proxy or your own server. Default is api.openai.com
         public let host: String
         public let port: Int
+        public let pathPrefix: String
         public let scheme: String
         /// Default request timeout
         public let timeoutInterval: TimeInterval
         
-        public init(token: String, organizationIdentifier: String? = nil, host: String = "api.openai.com", port: Int = 443, scheme: String = "https", timeoutInterval: TimeInterval = 60.0) {
+        public init(token: String, organizationIdentifier: String? = nil, host: String = "api.openai.com", port: Int = 443, pathPrefix: String = "", scheme: String = "https", timeoutInterval: TimeInterval = 60.0) {
             self.token = token
             self.organizationIdentifier = organizationIdentifier
             self.host = host
             self.port = port
             self.scheme = scheme
+            self.pathPrefix = pathPrefix
             self.timeoutInterval = timeoutInterval
         }
     }
@@ -202,7 +204,7 @@ extension OpenAI {
         components.scheme = configuration.scheme
         components.host = configuration.host
         components.port = configuration.port
-        components.path = path
+        components.path = configuration.pathPrefix + path
         return components.url!
     }
 }


### PR DESCRIPTION
## What
Add `pathPrefix` to OpenAI.Configuration.

## Why
This is needed for reverse proxy servers - for example, if the proxy server has the next path: `some-proxy-server.com/api`, and it will be passed as `host` - `func buildURL(path: String) -> URL` method will crash because `some-proxy-server.com/api` is not a valid host. 

The fix for this issue is to add `pathPrefix`, which will be added before each `path` when building a URL. So in provided example, `some-proxy-server.com/api` will be splitter to `host: "some-proxy-server.com", pathPrefix: "/api"`

## Affected Areas
Added new property `pathPrefix` to `OpenAI.Configuration` 