### PR TITLE
Fixes the `m4a` content type sent as `mp4` instead

### DIFF
--- a/Sources/OpenAI/Public/Models/AudioTranscriptionQuery.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranscriptionQuery.swift
@@ -58,8 +58,6 @@ public enum ResponseFormat: String, Codable, Equatable, CaseIterable {
             switch self {
             case .mpga:
                 fileName += Self.mp3.rawValue
-            case .m4a:
-                fileName += Self.mp4.rawValue
             default:
                 fileName += self.rawValue
             }
@@ -72,8 +70,6 @@ public enum ResponseFormat: String, Codable, Equatable, CaseIterable {
             switch self {
             case .mpga:
                 contentType += Self.mp3.rawValue
-            case .m4a:
-                contentType += Self.mp4.rawValue
             default:
                 contentType += self.rawValue
             }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 – you're very welcome! -->

## What

It fixes the trouble caused by sending the content type for `m4a` as `mp4`.
Fixes #194 and #195.

## Why

Out of nothing, I started to get `message : "Invalid file format. Supported formats: [\'flac\', \'m4a\', \'mp3\', \'mp4\', \'mpeg\', \'mpga\', \'oga\', \'ogg\', \'wav\', \'webm\']"` error when I try to transcribe my voice records. The weird part was that the file type was `m4a` and was in the supported formats list.

The code was as follows:
```swift
client.audioTranscriptions(query: .init(file: data, fileType: .m4a, model: .whisper_1)) { /* ... */ }
```

## Affected Areas

[AudioTranscriptionQuery.swift](https://github.com/MacPaw/OpenAI/compare/main...Demircivi:OpenAI:main#diff-d4c5e14bf9ea26581d2c32264ab0dbe4f965a3048531027c33096c37d9c7c760)