### PR TITLE
 feat: implement cancellable

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -63,8 +63,8 @@ final public class OpenAI: OpenAIProtocol {
         performRequest(request: JSONRequest<CompletionsResult>(body: query, url: buildURL(path: .completions)), completion: completion)
     }
     
-    public func completionsStream(query: CompletionsQuery, control: StreamControl, onResult: @escaping (Result<CompletionsResult, Error>) -> Void, completion: ((Error?) -> Void)?) {
-        performSteamingRequest(request: JSONRequest<CompletionsResult>(body: query.makeStreamable(), url: buildURL(path: configuration.apiPath.completions)), control: control, onResult: onResult, completion: completion)
+    public func completionsStream(query: CompletionsQuery, control: StreamControl = StreamControl(), onResult: @escaping (Result<CompletionsResult, Error>) -> Void, completion: ((Error?) -> Void)?) {
+        performStreamingRequest(request: JSONRequest<CompletionsResult>(body: query.makeStreamable(), url: buildURL(path: .completions)), control: control, onResult: onResult, completion: completion)
     }
     
     public func images(query: ImagesQuery, completion: @escaping (Result<ImagesResult, Error>) -> Void) {
@@ -87,10 +87,18 @@ final public class OpenAI: OpenAIProtocol {
         performRequest(request: JSONRequest<ChatResult>(body: query, url: buildURL(path: .chats)), completion: completion)
     }
     
-    public func chatsStream(query: ChatQuery, control: StreamControl, onResult: @escaping (Result<ChatStreamResult, Error>) -> Void, completion: ((Error?) -> Void)?) {
-        performSteamingRequest(request: JSONRequest<ChatResult>(body: query.makeStreamable(), url: buildURL(path: configuration.apiPath.chats)), control: control, onResult: onResult, completion: completion)
+    public func chatsStream(query: ChatQuery, onResult: @escaping (Result<ChatStreamResult, Error>) -> Void, completion: ((Error?) -> Void)?) {
+        performStreamingRequest(request: JSONRequest<ChatResult>(body: query.makeStreamable(), url: buildURL(path: .chats)), onResult: onResult, completion: completion)
     }
     
+    public func chatsStream(query: ChatQuery, control: StreamControl = StreamControl(), onResult: @escaping (Result<ChatStreamResult, Error>) -> Void, completion: ((Error?) -> Void)?) {
+        performStreamingRequest(request: JSONRequest<ChatResult>(body: query.makeStreamable(), url: buildURL(path: .chats)), control: control, onResult: onResult, completion: completion)
+    }
+    
+    public func chatsStream(query: ChatQuery, url: URL, control: StreamControl = StreamControl(), onResult: @escaping (Result<ChatStreamResult, Error>) -> Void, completion: ((Error?) -> Void)?) {
+        performStreamingRequest(request: JSONRequest<ChatStreamResult>(body: query.makeStreamable(), url: url), control: control, onResult: onResult, completion: completion)
+    }
+        
     public func edits(query: EditsQuery, completion: @escaping (Result<EditsResult, Error>) -> Void) {
         performRequest(request: JSONRequest<EditsResult>(body: query, url: buildURL(path: .edits)), completion: completion)
     }
@@ -149,7 +157,7 @@ extension OpenAI {
         }
     }
     
-    func performSteamingRequest<ResultType: Codable>(request: any URLRequestBuildable, control: StreamControl, onResult: @escaping (Result<ResultType, Error>) -> Void, completion: ((Error?) -> Void)?) {
+    func performStreamingRequest<ResultType: Codable>(request: any URLRequestBuildable, control: StreamControl = StreamControl(), onResult: @escaping (Result<ResultType, Error>) -> Void, completion: ((Error?) -> Void)?) {
         do {
             let request = try request.build(token: configuration.token, 
                                             organizationIdentifier: configuration.organizationIdentifier,

--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -9,8 +9,9 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+import Combine
 
-final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSessionDelegate, URLSessionDataDelegate {
+final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSessionDelegate, URLSessionDataDelegate, Cancellable {
     
     enum StreamingError: Error {
         case unknownContent
@@ -30,14 +31,21 @@ final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSe
     
     private var previousChunkBuffer = ""
 
+    // Property to keep track of the URLSessionTask
+        private var dataTask: URLSessionDataTask?
+    
     init(urlRequest: URLRequest) {
         self.urlRequest = urlRequest
     }
     
     func perform() {
-        self.urlSession
-            .dataTask(with: self.urlRequest)
-            .resume()
+        dataTask = self.urlSession.dataTask(with: self.urlRequest)
+        dataTask?.resume()
+    }
+    
+    // Method to cancel the URLSessionTask
+    func cancel() {
+        dataTask?.cancel()
     }
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {

--- a/Sources/OpenAI/Public/Models/StreamControl.swift
+++ b/Sources/OpenAI/Public/Models/StreamControl.swift
@@ -1,0 +1,21 @@
+//
+//  StreamControl.swift
+//
+//
+//  Created by Daniel Nguyen on 4/24/24.
+//
+
+import Foundation
+
+public class StreamControl {
+    private var session: StreamingSession<ChatStreamResult>? = nil
+
+    func setSession(_ session: StreamingSession<ChatStreamResult>) {
+        self.session = session
+    }
+    
+    func cancel() {
+        self.session?.cancel()
+        self.session = nil
+    }
+}

--- a/Sources/OpenAI/Public/Models/StreamControl.swift
+++ b/Sources/OpenAI/Public/Models/StreamControl.swift
@@ -14,7 +14,9 @@ public class StreamControl {
         self.session = session
     }
     
-    func cancel() {
+    public init() {}
+    
+    public func cancel() {
         self.session?.cancel()
         self.session = nil
     }

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -30,11 +30,16 @@ public extension OpenAIProtocol {
     func completionsStream(
         query: CompletionsQuery
     ) -> AsyncThrowingStream<CompletionsResult, Error> {
+        let control = StreamControl()
         return AsyncThrowingStream { continuation in
-            return completionsStream(query: query) { result in
+            completionsStream(query: query, control: control) { result in
                 continuation.yield(with: result)
             } completion: { error in
                 continuation.finish(throwing: error)
+            }
+            
+            continuation.onTermination = { @Sendable termination in
+                control.cancel()
             }
         }
     }
@@ -117,11 +122,17 @@ public extension OpenAIProtocol {
     func chatsStream(
         query: ChatQuery
     ) -> AsyncThrowingStream<ChatStreamResult, Error> {
+        let control = StreamControl()
+        
         return AsyncThrowingStream { continuation in
-            return chatsStream(query: query)  { result in
+            chatsStream(query: query, control: control)  { result in
                 continuation.yield(with: result)
             } completion: { error in
                 continuation.finish(throwing: error)
+            }
+            
+            continuation.onTermination = { @Sendable termination in
+                control.cancel()
             }
         }
     }

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -28,9 +28,9 @@ public extension OpenAIProtocol {
     }
     
     func completionsStream(
-        query: CompletionsQuery
+        query: CompletionsQuery,
+        control: StreamControl = StreamControl()
     ) -> AsyncThrowingStream<CompletionsResult, Error> {
-        let control = StreamControl()
         return AsyncThrowingStream { continuation in
             completionsStream(query: query, control: control) { result in
                 continuation.yield(with: result)
@@ -120,12 +120,29 @@ public extension OpenAIProtocol {
     }
     
     func chatsStream(
-        query: ChatQuery
+        query: ChatQuery,
+        control: StreamControl = StreamControl()
     ) -> AsyncThrowingStream<ChatStreamResult, Error> {
-        let control = StreamControl()
-        
         return AsyncThrowingStream { continuation in
             chatsStream(query: query, control: control)  { result in
+                continuation.yield(with: result)
+            } completion: { error in
+                continuation.finish(throwing: error)
+            }
+            
+            continuation.onTermination = { @Sendable termination in
+                control.cancel()
+            }
+        }
+    }
+    
+    func chatsStream(
+        query: ChatQuery,
+        url: URL,
+        control: StreamControl = StreamControl()
+    ) -> AsyncThrowingStream<ChatStreamResult, Error> {
+        return AsyncThrowingStream { continuation in
+            chatsStream(query: query, url: url, control: control)  { result in
                 continuation.yield(with: result)
             } completion: { error in
                 continuation.finish(throwing: error)

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
@@ -24,7 +24,8 @@ public extension OpenAIProtocol {
     
     func completionsStream(query: CompletionsQuery) -> AnyPublisher<Result<CompletionsResult, Error>, Error> {
         let progress = PassthroughSubject<Result<CompletionsResult, Error>, Error>()
-        completionsStream(query: query) { result in
+        let control = StreamControl()
+        completionsStream(query: query, control: control) { result in
             progress.send(result)
         } completion: { error in
             if let error {
@@ -73,7 +74,8 @@ public extension OpenAIProtocol {
     
     func chatsStream(query: ChatQuery) -> AnyPublisher<Result<ChatStreamResult, Error>, Error> {
         let progress = PassthroughSubject<Result<ChatStreamResult, Error>, Error>()
-        chatsStream(query: query) { result in
+        let control = StreamControl()
+        chatsStream(query: query, control: control) { result in
             progress.send(result)
         } completion: { error in
             if let error {

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
@@ -1,6 +1,6 @@
 //
 //  OpenAIProtocol+Combine.swift
-//  
+//
 //
 //  Created by Sergii Kryvoblotskyi on 03/04/2023.
 //
@@ -8,13 +8,14 @@
 #if canImport(Combine)
 
 import Combine
+import Foundation
 
 @available(iOS 13.0, *)
 @available(tvOS 13.0, *)
 @available(macOS 10.15, *)
 @available(watchOS 6.0, *)
 public extension OpenAIProtocol {
-
+    
     func completions(query: CompletionsQuery) -> AnyPublisher<CompletionsResult, Error> {
         Future<CompletionsResult, Error> {
             completions(query: query, completion: $0)
@@ -22,9 +23,10 @@ public extension OpenAIProtocol {
         .eraseToAnyPublisher()
     }
     
-    func completionsStream(query: CompletionsQuery) -> AnyPublisher<Result<CompletionsResult, Error>, Error> {
+    func completionsStream(query: CompletionsQuery,
+                           control: StreamControl = StreamControl()
+    ) -> AnyPublisher<Result<CompletionsResult, Error>, Error> {
         let progress = PassthroughSubject<Result<CompletionsResult, Error>, Error>()
-        let control = StreamControl()
         completionsStream(query: query, control: control) { result in
             progress.send(result)
         } completion: { error in
@@ -36,7 +38,7 @@ public extension OpenAIProtocol {
         }
         return progress.eraseToAnyPublisher()
     }
-
+    
     func images(query: ImagesQuery) -> AnyPublisher<ImagesResult, Error> {
         Future<ImagesResult, Error> {
             images(query: query, completion: $0)
@@ -57,14 +59,14 @@ public extension OpenAIProtocol {
         }
         .eraseToAnyPublisher()
     }
-
+    
     func embeddings(query: EmbeddingsQuery) -> AnyPublisher<EmbeddingsResult, Error> {
         Future<EmbeddingsResult, Error> {
             embeddings(query: query, completion: $0)
         }
         .eraseToAnyPublisher()
     }
-
+    
     func chats(query: ChatQuery) -> AnyPublisher<ChatResult, Error> {
         Future<ChatResult, Error> {
             chats(query: query, completion: $0)
@@ -72,10 +74,28 @@ public extension OpenAIProtocol {
         .eraseToAnyPublisher()
     }
     
-    func chatsStream(query: ChatQuery) -> AnyPublisher<Result<ChatStreamResult, Error>, Error> {
+    func chatsStream(query: ChatQuery,
+                     control: StreamControl = StreamControl()
+    ) -> AnyPublisher<Result<ChatStreamResult, Error>, Error> {
         let progress = PassthroughSubject<Result<ChatStreamResult, Error>, Error>()
-        let control = StreamControl()
         chatsStream(query: query, control: control) { result in
+            progress.send(result)
+        } completion: { error in
+            if let error {
+                progress.send(completion: .failure(error))
+            } else {
+                progress.send(completion: .finished)
+            }
+        }
+        return progress.eraseToAnyPublisher()
+    }
+    
+    func chatsStream(query: ChatQuery,
+                     url: URL,
+                     control: StreamControl = StreamControl()
+    ) -> AnyPublisher<Result<ChatStreamResult, Error>, Error> {
+        let progress = PassthroughSubject<Result<ChatStreamResult, Error>, Error>()
+        chatsStream(query: query, url: url, control: control) { result in
             progress.send(result)
         } completion: { error in
             if let error {
@@ -114,21 +134,21 @@ public extension OpenAIProtocol {
         }
         .eraseToAnyPublisher()
     }
-
+    
     func audioCreateSpeech(query: AudioSpeechQuery) -> AnyPublisher<AudioSpeechResult, Error> {
         Future<AudioSpeechResult, Error> {
             audioCreateSpeech(query: query, completion: $0)
         }
         .eraseToAnyPublisher()
     }
-
+    
     func audioTranscriptions(query: AudioTranscriptionQuery) -> AnyPublisher<AudioTranscriptionResult, Error> {
         Future<AudioTranscriptionResult, Error> {
             audioTranscriptions(query: query, completion: $0)
         }
         .eraseToAnyPublisher()
     }
-
+    
     func audioTranslations(query: AudioTranslationQuery) -> AnyPublisher<AudioTranslationResult, Error> {
         Future<AudioTranslationResult, Error> {
             audioTranslations(query: query, completion: $0)

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -148,6 +148,13 @@ public protocol OpenAIProtocol {
     func chatsStream(query: ChatQuery, control: StreamControl, onResult: @escaping (Result<ChatStreamResult, Error>) -> Void, completion: ((Error?) -> Void)?)
     
     /**
+     This function sends a chat query to the OpenAI API and retrieves chat stream conversation responses. 
+     
+     The Chat API enables you to use custom url to start a chat query.
+    **/
+    func chatsStream(query: ChatQuery, url: URL, control: StreamControl, onResult: @escaping (Result<ChatStreamResult, Error>) -> Void, completion: ((Error?) -> Void)?)
+    
+    /**
      This function sends an edits query to the OpenAI API and retrieves an edited version of the prompt based on the instruction given.
      
      Example:

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -42,7 +42,7 @@ public protocol OpenAIProtocol {
        - onResult: A closure which receives the result when the API request finishes. The closure's parameter, `Result<CompletionsResult, Error>`, will contain either the `CompletionsResult` object with the generated completions, or an error if the request failed.
        - completion: A closure that is being called when all chunks are delivered or uncrecoverable error occured
     **/
-    func completionsStream(query: CompletionsQuery, onResult: @escaping (Result<CompletionsResult, Error>) -> Void, completion: ((Error?) -> Void)?)
+    func completionsStream(query: CompletionsQuery, control: StreamControl, onResult: @escaping (Result<CompletionsResult, Error>) -> Void, completion: ((Error?) -> Void)?)
     
     /**
      This function sends an images query to the OpenAI API and retrieves generated images in response. The Images Generation API enables you to create various images or graphics using OpenAI's powerful deep learning models.
@@ -145,7 +145,7 @@ public protocol OpenAIProtocol {
        - onResult: A closure which receives the result when the API request finishes. The closure's parameter, `Result<ChatStreamResult, Error>`, will contain either the `ChatStreamResult` object with the model's response to the conversation, or an error if the request failed.
        - completion: A closure that is being called when all chunks are delivered or uncrecoverable error occured
     **/
-    func chatsStream(query: ChatQuery, onResult: @escaping (Result<ChatStreamResult, Error>) -> Void, completion: ((Error?) -> Void)?)
+    func chatsStream(query: ChatQuery, control: StreamControl, onResult: @escaping (Result<ChatStreamResult, Error>) -> Void, completion: ((Error?) -> Void)?)
     
     /**
      This function sends an edits query to the OpenAI API and retrieves an edited version of the prompt based on the instruction given.


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

<!-- Please describe the change -->

Enable user to cancel stream request, I just picked up the commit from  https://github.com/longseespace/OpenAI/commit/a290a1a119fc465cdb1740472242fbfca57069b9#diff-2a16b8014d00e2223611951c839756f88dd24a58d6d2d34962fa9c329eab6580

## Why

<!-- Please describe the motivation -->

Currently stream requests cannot be canceled once they are sent, which is bad.

## Affected Areas

<!-- Please describe what parts of the library are affected by the change -->
