### PR TITLE
Feat: Structured Outputs for function calling

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatQuery.swift
+++ b/Sources/OpenAI/Public/Models/ChatQuery.swift
@@ -703,6 +703,7 @@ public struct ChatQuery: Equatable, Codable, Streamable {
                 public let multipleOf: Int?
                 public let minimum: Int?
                 public let maximum: Int?
+                public let additionalProperties: Bool?
 
                 public init(
                     type: Self.JSONType,
@@ -713,7 +714,8 @@ public struct ChatQuery: Equatable, Codable, Streamable {
                     enum: [String]? = nil,
                     multipleOf: Int? = nil,
                     minimum: Int? = nil,
-                    maximum: Int? = nil
+                    maximum: Int? = nil,
+                    additionalProperties: Bool? = nil
                 ) {
                     self.type = type
                     self.properties = properties
@@ -724,6 +726,7 @@ public struct ChatQuery: Equatable, Codable, Streamable {
                     self.multipleOf = multipleOf
                     self.minimum = minimum
                     self.maximum = maximum
+                    self.additionalProperties = additionalProperties
                 }
 
                 public struct Property: Codable, Equatable {

--- a/Sources/OpenAI/Public/Models/ChatQuery.swift
+++ b/Sources/OpenAI/Public/Models/ChatQuery.swift
@@ -676,14 +676,19 @@ public struct ChatQuery: Equatable, Codable, Streamable {
             /// **Python library defines only [String: Object] dictionary.
             public let parameters: Self.FunctionParameters?
 
+            /// Whether to enable strict schema adherence when generating the function call. If set to true, the model will follow the exact schema defined in the parameters field. Only a subset of JSON Schema is supported when strict is true.
+            public let strict: Bool?
+
             public init(
                 name: String,
                 description: String? = nil,
-                parameters: Self.FunctionParameters? = nil
+                parameters: Self.FunctionParameters? = nil,
+                strict: Bool? = nil
             ) {
                 self.name = name
                 self.description = description
                 self.parameters = parameters
+                self.strict = strict
             }
 
             /// See the [guide](/docs/guides/gpt/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.

--- a/Tests/OpenAITests/OpenAITestsDecoder.swift
+++ b/Tests/OpenAITests/OpenAITestsDecoder.swift
@@ -264,7 +264,8 @@ class OpenAITestsDecoder: XCTestCase {
                           "location": .init(type: .string, description: "The city and state, e.g. San Francisco, CA"),
                           "unit": .init(type: .string, enum: ["celsius", "fahrenheit"])
                         ],
-                        required: ["location"]
+                        required: ["location"],
+                        additionalProperties: false
                       ),
                     strict: true
                 ))
@@ -293,7 +294,8 @@ class OpenAITestsDecoder: XCTestCase {
                     },
                     "unit": { "type": "string", "enum": ["celsius", "fahrenheit"] }
                   },
-                  "required": ["location"]
+                  "required": ["location"],
+                  "additionalProperties": false
                 },
                 "strict": true
               },


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Support the optional `strict` parameter in function definitions, which was released with Structured Outputs.

When `strict` is provided, the API requires `additionalProperties` to be provided in the `parameters` object of the function definition as well.

The earliest models that support this feature are `gpt-4o-2024-08-06` and `gpt-4o-mini-2024-07-18`.

This does NOT include support for the `json_schema` response_format for Structured Outputs outside of function definitions.

## Why

This parameter improves the model's adherence to JSON schemas during function calls. [See more](https://openai.com/index/introducing-structured-outputs-in-the-api/)

## Affected Areas

Non-breaking change to decoder, since only optional parameters were added.
