### PR TITLE
fixed verboseJson encoding

### DIFF
--- a/Sources/OpenAI/Public/Models/AudioTranscriptionQuery.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranscriptionQuery.swift
@@ -88,7 +88,7 @@ extension AudioTranscriptionQuery: MultipartFormDataBodyEncodable {
             .string(paramName: "prompt", value: prompt),
             .string(paramName: "temperature", value: temperature),
             .string(paramName: "language", value: language),
-            .string(paramName: "response_format", value: responseFormat)
+            .string(paramName: "response_format", value: responseFormat?.rawValue)
         ])
         return bodyBuilder.build()
     }

--- a/Sources/OpenAI/Public/Models/AudioTranscriptionResult.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranscriptionResult.swift
@@ -8,7 +8,27 @@
 import Foundation
 
 public struct AudioTranscriptionResult: Codable, Equatable {
-
-    /// The transcribed text.
+    /// The task type (always "transcribe" for transcriptions)
+    public let task: String?
+    /// The detected language
+    public let language: String?
+    /// The duration of the audio in seconds
+    public let duration: Double?
+    /// The transcribed text
     public let text: String
+    /// The segments containing detailed information (only present in verbose_json format)
+    public let segments: [Segment]?
+    
+    public struct Segment: Codable, Equatable {
+        public let id: Int
+        public let seek: Int
+        public let start: Double
+        public let end: Double
+        public let text: String
+        public let tokens: [Int]
+        public let temperature: Double
+        public let avg_logprob: Double
+        public let compression_ratio: Double
+        public let no_speech_prob: Double
+    }
 }

--- a/Sources/OpenAI/Public/Models/AudioTranscriptionResult.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranscriptionResult.swift
@@ -18,7 +18,21 @@ public struct AudioTranscriptionResult: Codable, Equatable {
     public let text: String
     /// The segments containing detailed information (only present in verbose_json format)
     public let segments: [Segment]?
-    
+
+    public init(
+        task: String? = nil,
+        language: String? = nil,
+        duration: Double? = nil,
+        text: String,
+        segments: [Segment]? = nil
+    ) {
+        self.task = task
+        self.language = language
+        self.duration = duration
+        self.text = text
+        self.segments = segments
+    }
+        
     public struct Segment: Codable, Equatable {
         public let id: Int
         public let seek: Int

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -320,7 +320,38 @@ class OpenAITests: XCTestCase {
         let result = try await openAI.audioTranscriptions(query: query)
         XCTAssertEqual(result, transcriptionResult)
     }
-    
+
+    func testVerboseJsonAudioTranscriptions() async throws {
+        let data = Data()
+        let query = AudioTranscriptionQuery(file: data, fileType: .m4a, model: .whisper_1, responseFormat: .verboseJson)
+
+        let transcriptionResult = AudioTranscriptionResult(
+            task: "transcribe",
+            language: "english",
+            duration: 3.759999990463257,
+            text: "This is a test.",
+            segments: [
+                AudioTranscriptionResult.Segment(
+                    id: 0,
+                    seek: 0,
+                    start: 0,
+                    end: 3.759999990463257,
+                    text: " This is a test.",
+                    tokens: [50364, 639, 307, 257, 1500, 13, 50552],
+                    temperature: 0,
+                    avg_logprob: -0.5153926610946655,
+                    compression_ratio: 0.7142857313156128,
+                    no_speech_prob: 0.08552933484315872
+                )
+            ]
+        )
+
+        try self.stub(result: transcriptionResult)
+
+        let result = try await openAI.audioTranscriptions(query: query)
+        XCTAssertEqual(result, transcriptionResult)
+    }
+
     func testAudioTranscriptionsError() async throws {
         let data = Data()
         let query = AudioTranscriptionQuery(file: data, fileType: .m4a, model: .whisper_1)


### PR DESCRIPTION
## What

This fixes the verboseJson encoding. I tested it with verboseJson, and works still with text as well.

## Why

I got this error: Transcription failed: APIErrorResponse(error: OpenAI.APIError(message: "[{\'type\': \'enum\', \'loc\': (\'body\', \'response_format\'), \'msg\': \"Input should be \'json\', \'text\', \'vtt\', \'srt\' or \'verbose_json\'\", \'input\': \'verboseJson\', \'ctx\': {\'expected\': \"\'json\', \'text\', \'vtt\', \'srt\' or \'verbose_json\'\"}}]", type: "invalid_request_error", param: nil, code: nil))

because verboseJson was not encoded as verbose_json.

## Affected Areas

AudioTranscriptionQuery
