### PR TITLE
Bug: Add initializer for ToolCallParam.FunctionCall

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatQuery.swift
+++ b/Sources/OpenAI/Public/Models/ChatQuery.swift
@@ -539,6 +539,14 @@ public struct ChatQuery: Equatable, Codable, Streamable {
                     public let arguments: String
                     /// The name of the function to call.
                     public let name: String
+
+                    public init(
+                        arguments: String,
+                        name: String
+                    ) {
+                        self.arguments = arguments
+                        self.name = name
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What

Add an initializer for ToolCallParam.FunctionCall

## Why

Cannot initialize without it. I have a use case that requires me to initialize a ToolCallParam (instead of using one returned by the SDK).

## Affected Areas

Chat Completion API
