### PR TITLE
Support comments in streaming response

### DIFF
--- a/Sources/OpenAI/Private/StreamInterpreter.swift
+++ b/Sources/OpenAI/Private/StreamInterpreter.swift
@@ -1,0 +1,78 @@
+//
+//  StreamInterpreter.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 03.02.2025.
+//
+
+import Foundation
+
+/// https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+/// 9.2.6 Interpreting an event stream
+class StreamInterpreter<ResultType: Codable> {
+    private let streamingCompletionMarker = "[DONE]"
+    private var previousChunkBuffer = ""
+    
+    var onEventDispatched: ((ResultType) -> Void)?
+    
+    func processData(_ data: Data) throws {
+        guard let stringContent = String(data: data, encoding: .utf8) else {
+            throw StreamingError.unknownContent
+        }
+        try processJSON(from: stringContent)
+    }
+    
+    private func processJSON(from stringContent: String) throws {
+        if stringContent.isEmpty {
+            return
+        }
+
+        let fullChunk = "\(previousChunkBuffer)\(stringContent)"
+        let chunkLines = fullChunk
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+
+        var jsonObjects: [String] = []
+        for line in chunkLines {
+
+            // Skip comments
+            if line.starts(with: ":") { continue }
+
+            // Get JSON object
+            let jsonData = line
+                .components(separatedBy: "data:")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { $0.isEmpty == false }
+            jsonObjects.append(contentsOf: jsonData)
+        }
+
+        previousChunkBuffer = ""
+        
+        guard jsonObjects.isEmpty == false, jsonObjects.first != streamingCompletionMarker else {
+            return
+        }
+        
+        try jsonObjects.enumerated().forEach { (index, jsonContent)  in
+            guard jsonContent != streamingCompletionMarker && !jsonContent.isEmpty else {
+                return
+            }
+            guard let jsonData = jsonContent.data(using: .utf8) else {
+                throw StreamingError.unknownContent
+            }
+            let decoder = JSONDecoder()
+            do {
+                let object = try decoder.decode(ResultType.self, from: jsonData)
+                onEventDispatched?(object)
+            } catch {
+                if let decoded = try? decoder.decode(APIErrorResponse.self, from: jsonData) {
+                    throw decoded
+                } else if index == jsonObjects.count - 1 {
+                    previousChunkBuffer = "data: \(jsonContent)" // Chunk ends in a partial JSON
+                } else {
+                    throw error
+                }
+            }
+        }
+    }
+}

--- a/Sources/OpenAI/Private/StreamingError.swift
+++ b/Sources/OpenAI/Private/StreamingError.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 03.02.2025.
+//
+
+import Foundation
+
+enum StreamingError: Error {
+    case unknownContent
+    case emptyContent
+}

--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -1,6 +1,6 @@
 //
 //  StreamingSession.swift
-//  
+//
 //
 //  Created by Sergii Kryvoblotskyi on 18/04/2023.
 //
@@ -11,27 +11,22 @@ import FoundationNetworking
 #endif
 
 final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSessionDelegate, URLSessionDataDelegate {
-    
-    enum StreamingError: Error {
-        case unknownContent
-        case emptyContent
-    }
-    
     var onReceiveContent: ((StreamingSession, ResultType) -> Void)?
     var onProcessingError: ((StreamingSession, Error) -> Void)?
     var onComplete: ((StreamingSession, Error?) -> Void)?
     
-    private let streamingCompletionMarker = "[DONE]"
     private let urlRequest: URLRequest
     private lazy var urlSession: URLSession = {
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
         return session
     }()
     
-    private var previousChunkBuffer = ""
+    private let interpreter = StreamInterpreter<ResultType>()
 
     init(urlRequest: URLRequest) {
         self.urlRequest = urlRequest
+        super.init()
+        subscribeToParser()
     }
     
     func perform() {
@@ -45,69 +40,17 @@ final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSe
     }
     
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        guard let stringContent = String(data: data, encoding: .utf8) else {
-            onProcessingError?(self, StreamingError.unknownContent)
-            return
-        }
-        processJSON(from: stringContent)
-    }
-    
-}
-
-extension StreamingSession {
-    
-    private func processJSON(from stringContent: String) {
-        if stringContent.isEmpty {
-            return
-        }
-
-        let fullChunk = "\(previousChunkBuffer)\(stringContent)"
-        let chunkLines = fullChunk
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { $0.isEmpty == false }
-
-        var jsonObjects: [String] = []
-        for line in chunkLines {
-
-            // Skip comments
-            if line.starts(with: ":") { continue }
-
-            // Get JSON object
-            let jsonData = line
-                .components(separatedBy: "data:")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { $0.isEmpty == false }
-            jsonObjects.append(contentsOf: jsonData)
-        }
-
-        previousChunkBuffer = ""
-        
-        guard jsonObjects.isEmpty == false, jsonObjects.first != streamingCompletionMarker else {
-            return
-        }
-        jsonObjects.enumerated().forEach { (index, jsonContent)  in
-            guard jsonContent != streamingCompletionMarker && !jsonContent.isEmpty else {
-                return
-            }
-            guard let jsonData = jsonContent.data(using: .utf8) else {
-                onProcessingError?(self, StreamingError.unknownContent)
-                return
-            }
-            let decoder = JSONDecoder()
-            do {
-                let object = try decoder.decode(ResultType.self, from: jsonData)
-                onReceiveContent?(self, object)
-            } catch {
-                if let decoded = try? decoder.decode(APIErrorResponse.self, from: jsonData) {
-                    onProcessingError?(self, decoded)
-                } else if index == jsonObjects.count - 1 {
-                    previousChunkBuffer = "data: \(jsonContent)" // Chunk ends in a partial JSON
-                } else {
-                    onProcessingError?(self, error)
-                }
-            }
+        do {
+            try interpreter.processData(data)
+        } catch {
+            onProcessingError?(self, error)
         }
     }
     
+    private func subscribeToParser() {
+        interpreter.onEventDispatched = { [weak self] content in
+            guard let self else { return }
+            self.onReceiveContent?(self, content)
+        }
+    }
 }

--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -60,11 +60,26 @@ extension StreamingSession {
         if stringContent.isEmpty {
             return
         }
-        let jsonObjects = "\(previousChunkBuffer)\(stringContent)"
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .components(separatedBy: "data:")
+
+        let fullChunk = "\(previousChunkBuffer)\(stringContent)"
+        let chunkLines = fullChunk
+            .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { $0.isEmpty == false }
+
+        var jsonObjects: [String] = []
+        for line in chunkLines {
+
+            // Skip comments
+            if line.starts(with: ":") { continue }
+
+            // Get JSON object
+            let jsonData = line
+                .components(separatedBy: "data:")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { $0.isEmpty == false }
+            jsonObjects.append(contentsOf: jsonData)
+        }
 
         previousChunkBuffer = ""
         

--- a/Tests/OpenAITests/StreamInterpreterTests.swift
+++ b/Tests/OpenAITests/StreamInterpreterTests.swift
@@ -1,0 +1,47 @@
+//
+//  StreamInterpreterTests.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 03.02.2025.
+//
+
+import Testing
+import Foundation
+@testable import OpenAI
+
+struct StreamInterpreterTests {
+    let interpreter = StreamInterpreter<ChatStreamResult>()
+    
+    @Test func testParseShortMessageResponseStream() throws {
+        var chatStreamResults: [ChatStreamResult] = []
+        interpreter.onEventDispatched = { chatStreamResults.append($0) }
+        
+        try interpreter.processData(chatCompletionChunk())
+        try interpreter.processData(chatCompletionChunkTermination())
+        #expect(chatStreamResults.count == 3)
+    }
+    
+    // https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+    // If the line starts with a U+003A COLON character (:)
+    // - Ignore the line.
+    @Test func testIgnoresLinesStartingWithColon() throws {
+        var chatStreamResults: [ChatStreamResult] = []
+        interpreter.onEventDispatched = { chatStreamResults.append($0) }
+        
+        try interpreter.processData(chatCompletionChunkWithComment())
+        #expect(chatStreamResults.count == 1)
+    }
+    
+    // Chunk with 3 objects. I captured it from a real response. It's a very short response that contains just "Hi"
+    private func chatCompletionChunk() -> Data {
+        "data: {\"id\":\"chatcmpl-AwnboO5ZnaUyii9xxC5ZVmM5vGark\",\"object\":\"chat.completion.chunk\",\"created\":1738577084,\"model\":\"gpt-4-0613\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-AwnboO5ZnaUyii9xxC5ZVmM5vGark\",\"object\":\"chat.completion.chunk\",\"created\":1738577084,\"model\":\"gpt-4-0613\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi\"},\"logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-AwnboO5ZnaUyii9xxC5ZVmM5vGark\",\"object\":\"chat.completion.chunk\",\"created\":1738577084,\"model\":\"gpt-4-0613\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}]}\n\n".data(using: .utf8)!
+    }
+    
+    private func chatCompletionChunkWithComment() -> Data {
+        ": OPENROUTER PROCESSING\n\ndata: {\"id\":\"chatcmpl-AwnboO5ZnaUyii9xxC5ZVmM5vGark\",\"object\":\"chat.completion.chunk\",\"created\":1738577084,\"model\":\"gpt-4-0613\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}]}\n\n".data(using: .utf8)!
+    }
+    
+    private func chatCompletionChunkTermination() -> Data {
+        "data: [DONE]\n\n".data(using: .utf8)!
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

This PR adjusts the streaming response parsing logic to gracefully deal with comments.
Supersedes #252.

<!-- Please describe the change -->

## Why

Server Sent Events, the standard used by the OpenAI API and compatible APIs, support comments by definition[^1], but the parsing code did not deal with them gracefully. Instead, it caused a decoding error, trying to parse the comment as JSON.

Even though the official OpenAI API does not seem to be using comments as far as I can tell, other OpenAI-compatible APIs are using them (e.g. OpenRouter), and they are part of the standard, so should probably be supported anyway.

~Honestly, that part of the code probably needs a bigger overhaul in the future, because the parsing logic there is far from robust, and far from correct. It's correct enough to handle the specific way that OpenAI is using Server Sent Events, but it ignores many parts of the spec, such as multi-line events that can have multiple `data:` parts while still being the same event.~

The PR now includes a refactoring of the stream data processing code, and I think that mostly addresses these claims I made earlier. Probably still needs some stricter compliance testing to make sure we handle edge-cases well, but it's more than good enough for me in its current state.

[^1]: https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream

<!-- Please describe the motivation -->

## Affected Areas

Only the stream response parsing is affected.

<!-- Please describe what parts of the library are affected by the change -->

## Mentions

Huge thanks to @nezhyborets for contributing tests and refactoring!
