### PR TITLE
Add customHeaders to configuration

### DIFF
--- a/Sources/OpenAI/OpenAI+OpenAIAsync.swift
+++ b/Sources/OpenAI/OpenAI+OpenAIAsync.swift
@@ -183,9 +183,8 @@ extension OpenAI: OpenAIAsync {
     }
     
     func performRequestAsync<ResultType: Codable>(request: any URLRequestBuildable) async throws -> ResultType {
-        let urlRequest = try request.build(token: configuration.token,
-                                        organizationIdentifier: configuration.organizationIdentifier,
-                                        timeoutInterval: configuration.timeoutInterval)
+        let urlRequest = try request.build(configuration: configuration)
+        
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             let (data, _) = try await session.data(for: urlRequest, delegate: nil)
             let decoder = JSONDecoder()

--- a/Sources/OpenAI/OpenAI+OpenAICombine.swift
+++ b/Sources/OpenAI/OpenAI+OpenAICombine.swift
@@ -179,9 +179,8 @@ extension OpenAI: OpenAICombine {
     
     func performRequestCombine<ResultType: Codable>(request: any URLRequestBuildable) -> AnyPublisher<ResultType, Error> {
         do {
-            let request = try request.build(token: configuration.token,
-                                            organizationIdentifier: configuration.organizationIdentifier,
-                                            timeoutInterval: configuration.timeoutInterval)
+            let request = try request.build(configuration: configuration)
+            
             return session
                 .dataTaskPublisher(for: request)
                 .tryMap { (data, response) in

--- a/Sources/OpenAI/Private/AssistantsRequest.swift
+++ b/Sources/OpenAI/Private/AssistantsRequest.swift
@@ -34,8 +34,9 @@ struct AssistantsRequest<ResultType>: URLRequestBuildable {
         self.method = method
     }
     
-    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval) throws -> URLRequest {
-        let customHeaders = ["OpenAI-Beta": "assistants=v2"]
+    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval, customHeaders: [String: String]) throws -> URLRequest {
+        let customHeaders = customHeaders
+            .merging(["OpenAI-Beta": "assistants=v2"], uniquingKeysWith: { first, _ in first })
         
         switch body {
         case .json(let codable):
@@ -49,18 +50,19 @@ struct AssistantsRequest<ResultType>: URLRequestBuildable {
             return try jsonRequest.build(
                 token: token,
                 organizationIdentifier: organizationIdentifier,
-                timeoutInterval: timeoutInterval
+                timeoutInterval: timeoutInterval,
+                customHeaders: customHeaders
             )
         case .multipartFormData(let encodable):
             let request = MultipartFormDataRequest<ResultType>(
                 body: encodable,
-                url: urlBuilder.buildURL(),
-                customHeaders: customHeaders
+                url: urlBuilder.buildURL()
             )
             return try request.build(
                 token: token,
                 organizationIdentifier: organizationIdentifier,
-                timeoutInterval: timeoutInterval
+                timeoutInterval: timeoutInterval,
+                customHeaders: customHeaders
             )
         }
     }

--- a/Sources/OpenAI/Private/JSONRequest.swift
+++ b/Sources/OpenAI/Private/JSONRequest.swift
@@ -15,34 +15,33 @@ final class JSONRequest<ResultType> {
     let body: Codable?
     let url: URL
     let method: String
-    let customHeaders: [String: String]
     
     init(body: Codable? = nil, url: URL, method: String = "POST", customHeaders: [String: String] = [:]) {
         self.body = body
         self.url = url
         self.method = method
-        self.customHeaders = customHeaders
     }
 }
 
 extension JSONRequest: URLRequestBuildable {
-    
     func build(
         token: String,
         organizationIdentifier: String?,
-        timeoutInterval: TimeInterval
+        timeoutInterval: TimeInterval,
+        customHeaders: [String: String]
     ) throws -> URLRequest {
         var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         
-        for (headerField, value) in customHeaders {
-            request.setValue(value, forHTTPHeaderField: headerField)
-        }
-
         if let organizationIdentifier {
             request.setValue(organizationIdentifier, forHTTPHeaderField: "OpenAI-Organization")
         }
+        
+        for (headerField, value) in customHeaders {
+            request.setValue(value, forHTTPHeaderField: headerField)
+        }
+        
         request.httpMethod = method
         if let body = body {
             request.httpBody = try JSONEncoder().encode(body)
@@ -50,5 +49,3 @@ extension JSONRequest: URLRequestBuildable {
         return request
     }
 }
-
-

--- a/Sources/OpenAI/Private/MultipartFormDataRequest.swift
+++ b/Sources/OpenAI/Private/MultipartFormDataRequest.swift
@@ -15,19 +15,17 @@ final class MultipartFormDataRequest<ResultType> {
     let body: MultipartFormDataBodyEncodable
     let url: URL
     let method: String
-    let customHeaders: [String: String]
         
-    init(body: MultipartFormDataBodyEncodable, url: URL, method: String = "POST", customHeaders: [String: String] = [:]) {
+    init(body: MultipartFormDataBodyEncodable, url: URL, method: String = "POST") {
         self.body = body
         self.url = url
         self.method = method
-        self.customHeaders = customHeaders
     }
 }
 
 extension MultipartFormDataRequest: URLRequestBuildable {
     
-    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval) throws -> URLRequest {
+    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval, customHeaders: [String: String]) throws -> URLRequest {
         var request = URLRequest(url: url)
         let boundary: String = UUID().uuidString
         request.timeoutInterval = timeoutInterval

--- a/Sources/OpenAI/Private/URLRequestBuildable.swift
+++ b/Sources/OpenAI/Private/URLRequestBuildable.swift
@@ -11,5 +11,23 @@ import FoundationNetworking
 #endif
 
 protocol URLRequestBuildable {
-    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval) throws -> URLRequest
+    func build(
+        token: String,
+        organizationIdentifier: String?,
+        timeoutInterval: TimeInterval,
+        customHeaders: [String: String]
+    ) throws -> URLRequest
+}
+
+extension URLRequestBuildable {
+    func build(
+        configuration: OpenAI.Configuration
+    ) throws -> URLRequest {
+        try build(
+            token: configuration.token,
+            organizationIdentifier: configuration.organizationIdentifier,
+            timeoutInterval: configuration.timeoutInterval,
+            customHeaders: configuration.customHeaders
+        )
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Add new field to `OpenAI.Configuration` to let users set custom headers.

## Why

We support different providers, and they may require headers that are not set by SDK by default.

## Affected Areas

`OpenAI.Configuration`, building requests