### PR TITLE
Bug: Fix uploading file not working in Assistants, sometimes even causing crashes

### DIFF
--- a/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
@@ -138,7 +138,7 @@ struct AssistantModalContentView: View {
                     Button("Upload File") {
                         isPickerPresented = true
                     }
-                    .sheet(isPresented: $isPickerPresented) {
+                    .fullScreenCover(isPresented: $isPickerPresented) {
                         DocumentPicker { url in
                             selectedFileURL = url
                             onFileUpload()


### PR DESCRIPTION
## What

Uploading file not working in Assistants, sometimes even causing crashes.

## Why

It seems that SwiftUI's refresh mechanism causes the `DocumentPicker` to be released before the delegate has a chance to work.

## Affected Areas

The upload file selection UI (`DocumentPicker`) has slightly changed, as follows.

| Before | PR |
|:--:|:--:|
|![Simulator Screenshot - iPhone 16 Pro - 2025-02-15 at 19 34 14](https://github.com/user-attachments/assets/7b9538d0-2267-4460-8fc5-74734df1782f)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-15 at 19 39 57](https://github.com/user-attachments/assets/b20daae2-3400-4f87-aad8-771196b10500)|

## More Info
Crash lnfo:
<img width="1390" alt="截圖 2025-02-15 晚上7 31 51" src="https://github.com/user-attachments/assets/d0bcd302-5a3d-4429-a43d-4121c9278c93" />
