### PR TITLE
Bug: Fix error parsing in StreamInterpreter

### DIFF
--- a/Sources/OpenAI/Private/StreamInterpreter.swift
+++ b/Sources/OpenAI/Private/StreamInterpreter.swift
@@ -16,6 +16,11 @@ class StreamInterpreter<ResultType: Codable> {
     var onEventDispatched: ((ResultType) -> Void)?
     
     func processData(_ data: Data) throws {
+        let decoder = JSONDecoder()
+        if let decoded = try? decoder.decode(APIErrorResponse.self, from: data) {
+            throw decoded
+        }
+        
         guard let stringContent = String(data: data, encoding: .utf8) else {
             throw StreamingError.unknownContent
         }

--- a/Tests/OpenAITests/StreamInterpreterTests.swift
+++ b/Tests/OpenAITests/StreamInterpreterTests.swift
@@ -32,6 +32,14 @@ struct StreamInterpreterTests {
         #expect(chatStreamResults.count == 1)
     }
     
+    @Test func parseApiError() throws {
+        do {
+            try interpreter.processData(chatCompletionError())
+        } catch {
+            #expect(error is APIErrorResponse)
+        }
+    }
+    
     // Chunk with 3 objects. I captured it from a real response. It's a very short response that contains just "Hi"
     private func chatCompletionChunk() -> Data {
         "data: {\"id\":\"chatcmpl-AwnboO5ZnaUyii9xxC5ZVmM5vGark\",\"object\":\"chat.completion.chunk\",\"created\":1738577084,\"model\":\"gpt-4-0613\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-AwnboO5ZnaUyii9xxC5ZVmM5vGark\",\"object\":\"chat.completion.chunk\",\"created\":1738577084,\"model\":\"gpt-4-0613\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi\"},\"logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-AwnboO5ZnaUyii9xxC5ZVmM5vGark\",\"object\":\"chat.completion.chunk\",\"created\":1738577084,\"model\":\"gpt-4-0613\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}]}\n\n".data(using: .utf8)!
@@ -43,5 +51,10 @@ struct StreamInterpreterTests {
     
     private func chatCompletionChunkTermination() -> Data {
         "data: [DONE]\n\n".data(using: .utf8)!
+    }
+    
+    // Copied from an actual reponse that was an input to inreptreter
+    private func chatCompletionError() -> Data {
+        "{\n    \"error\": {\n        \"message\": \"The model `o3-mini` does not exist or you do not have access to it.\",\n        \"type\": \"invalid_request_error\",\n        \"param\": null,\n        \"code\": \"model_not_found\"\n    }\n}\n".data(using: .utf8)!
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Try parsing APIError on the whole response instead of later on divided pieces

## Why

To fix [the issue](https://github.com/MacPaw/OpenAI/issues/261#issuecomment-2663022284)

## Affected Areas

`StreamInterpreter`. Also, while debugging, I added an ability to demo to specify **non-streaming** way of completing conversations. Didn't add a UI to control that though. Added a task for that https://github.com/MacPaw/OpenAI/issues/265
