### PR TITLE
chore: update codeql actions versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@main
       with:
         languages: ${{ matrix.language }}
       
@@ -36,6 +36,6 @@ jobs:
       run: swift build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@main
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

- Update codeql actions versions

## Why

- CodeQL Action major versions v1 and v2 have been deprecated. For more information, see https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/

## Affected Areas

- CodeQL security checks
