### PR TITLE
feat:Support reasoningContent in StreamResult

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatStreamResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatStreamResult.swift
@@ -17,6 +17,9 @@ public struct ChatStreamResult: Codable, Equatable {
 
             /// The contents of the chunk message.
             public let content: String?
+            /// The reasoning content of the chunk message.
+            /// Only some model are supported, like DeepSeek-R1.
+            public let reasoningContent: String?
             /// The role of the author of this message.
             public let role: Self.Role?
             public let toolCalls: [Self.ChoiceDeltaToolCall]?
@@ -61,6 +64,7 @@ public struct ChatStreamResult: Codable, Equatable {
 
             public enum CodingKeys: String, CodingKey {
                 case content
+                case reasoningContent = "reasoning_content"
                 case role
                 case toolCalls = "tool_calls"
             }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Add `reasoningContent` to `ChatStreamResult.Choice.ChoiceDelta`

## Why

Support for the DeepSeek-R1 reasoning content response.

#271 

https://api-docs.deepseek.com/guides/reasoning_model

## Affected Areas

Incremental modification, nil if no return
