### PR TITLE
Make token optional

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -45,7 +45,7 @@ final public class OpenAI {
         /// Currently SDK sets such fields: Authorization, Content-Type, OpenAI-Organization.
         public let customHeaders: [String: String]
         
-        public init(token: String? = nil, organizationIdentifier: String? = nil, host: String = "api.openai.com", port: Int = 443, scheme: String = "https", basePath: String = "/v1", timeoutInterval: TimeInterval = 60.0, customHeaders: [String: String] = [:]) {
+        public init(token: String?, organizationIdentifier: String? = nil, host: String = "api.openai.com", port: Int = 443, scheme: String = "https", basePath: String = "/v1", timeoutInterval: TimeInterval = 60.0, customHeaders: [String: String] = [:]) {
             self.token = token
             self.organizationIdentifier = organizationIdentifier
             self.host = host

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -15,7 +15,11 @@ final public class OpenAI {
     public struct Configuration {
         
         /// OpenAI API token. See https://platform.openai.com/docs/api-reference/authentication
-        public let token: String
+        ///
+        /// Set the token when the app works directly with OpenAI API. This approach is generally unsafe and should not be used in production.
+        /// Default value is nil. It would work when you have a proxy server that manages authentication.
+        /// See https://github.com/MacPaw/OpenAI/discussions/116 for more info
+        public let token: String?
         
         /// Optional OpenAI organization identifier. See https://platform.openai.com/docs/api-reference/authentication
         public let organizationIdentifier: String?
@@ -41,7 +45,7 @@ final public class OpenAI {
         /// Currently SDK sets such fields: Authorization, Content-Type, OpenAI-Organization.
         public let customHeaders: [String: String]
         
-        public init(token: String, organizationIdentifier: String? = nil, host: String = "api.openai.com", port: Int = 443, scheme: String = "https", basePath: String = "/v1", timeoutInterval: TimeInterval = 60.0, customHeaders: [String: String] = [:]) {
+        public init(token: String? = nil, organizationIdentifier: String? = nil, host: String = "api.openai.com", port: Int = 443, scheme: String = "https", basePath: String = "/v1", timeoutInterval: TimeInterval = 60.0, customHeaders: [String: String] = [:]) {
             self.token = token
             self.organizationIdentifier = organizationIdentifier
             self.host = host

--- a/Sources/OpenAI/Private/AssistantsRequest.swift
+++ b/Sources/OpenAI/Private/AssistantsRequest.swift
@@ -34,7 +34,7 @@ struct AssistantsRequest<ResultType>: URLRequestBuildable {
         self.method = method
     }
     
-    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval, customHeaders: [String: String]) throws -> URLRequest {
+    func build(token: String?, organizationIdentifier: String?, timeoutInterval: TimeInterval, customHeaders: [String: String]) throws -> URLRequest {
         let customHeaders = customHeaders
             .merging(["OpenAI-Beta": "assistants=v2"], uniquingKeysWith: { first, _ in first })
         

--- a/Sources/OpenAI/Private/JSONRequest.swift
+++ b/Sources/OpenAI/Private/JSONRequest.swift
@@ -25,14 +25,17 @@ final class JSONRequest<ResultType> {
 
 extension JSONRequest: URLRequestBuildable {
     func build(
-        token: String,
+        token: String?,
         organizationIdentifier: String?,
         timeoutInterval: TimeInterval,
         customHeaders: [String: String]
     ) throws -> URLRequest {
         var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        
+        if let token {        
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
         
         if let organizationIdentifier {
             request.setValue(organizationIdentifier, forHTTPHeaderField: "OpenAI-Organization")

--- a/Sources/OpenAI/Private/MultipartFormDataRequest.swift
+++ b/Sources/OpenAI/Private/MultipartFormDataRequest.swift
@@ -25,12 +25,16 @@ final class MultipartFormDataRequest<ResultType> {
 
 extension MultipartFormDataRequest: URLRequestBuildable {
     
-    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval, customHeaders: [String: String]) throws -> URLRequest {
+    func build(token: String?, organizationIdentifier: String?, timeoutInterval: TimeInterval, customHeaders: [String: String]) throws -> URLRequest {
         var request = URLRequest(url: url)
         let boundary: String = UUID().uuidString
         request.timeoutInterval = timeoutInterval
         request.httpMethod = method
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        
+        if let token {        
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         if let organizationIdentifier {
             request.setValue(organizationIdentifier, forHTTPHeaderField: "OpenAI-Organization")

--- a/Sources/OpenAI/Private/URLRequestBuildable.swift
+++ b/Sources/OpenAI/Private/URLRequestBuildable.swift
@@ -12,7 +12,7 @@ import FoundationNetworking
 
 protocol URLRequestBuildable {
     func build(
-        token: String,
+        token: String?,
         organizationIdentifier: String?,
         timeoutInterval: TimeInterval,
         customHeaders: [String: String]

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -403,7 +403,7 @@ class OpenAITests: XCTestCase {
         let jsonRequest = JSONRequest<ChatResult>(body: completionQuery, url: URL(string: "http://google.com")!)
         let urlRequest = try jsonRequest.build(configuration: configuration)
         
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Authorization"), "Bearer \(configuration.token)")
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Authorization"), "Bearer \(configuration.token!)")
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "OpenAI-Organization"), configuration.organizationIdentifier)
         XCTAssertEqual(urlRequest.timeoutInterval, configuration.timeoutInterval)
@@ -415,7 +415,7 @@ class OpenAITests: XCTestCase {
         let multipartFormDataRequest = MultipartFormDataRequest<ChatResult>(body: completionQuery, url: URL(string: "http://google.com")!)
         let urlRequest = try multipartFormDataRequest.build(configuration: configuration)
         
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Authorization"), "Bearer \(configuration.token)")
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Authorization"), "Bearer \(configuration.token!)")
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "OpenAI-Organization"), configuration.organizationIdentifier)
         XCTAssertEqual(urlRequest.timeoutInterval, configuration.timeoutInterval)
     }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What
Make token to be optional instead of required

<!-- Please describe the change -->

## Why
This SDK would (only) work safe through proxy server, which would manage the authentication, thus there would be a lot of cases when token is not required on the client side.

<!-- Please describe the motivation -->

## Affected Areas

OpenAI.Configuration. URL request builders.

<!-- Please describe what parts of the library are affected by the change -->
