### PR TITLE
Improve function call handling and update default model to GPT4-O-Mini

### DIFF
--- a/Demo/DemoChat/Sources/UI/DetailView.swift
+++ b/Demo/DemoChat/Sources/UI/DetailView.swift
@@ -17,7 +17,7 @@ struct DetailView: View {
     @State var inputText: String = ""
     @FocusState private var isFocused: Bool
     @State private var showsModelSelectionSheet = false
-    @State private var selectedChatModel: Model = .gpt4_0613
+    @State private var selectedChatModel: Model = .gpt4_o_mini
     var availableAssistants: [Assistant]
 
     private static let availableChatModels: [Model] = [.gpt3_5Turbo, .gpt4]

--- a/Demo/DemoChat/Sources/UI/DetailView.swift
+++ b/Demo/DemoChat/Sources/UI/DetailView.swift
@@ -20,7 +20,7 @@ struct DetailView: View {
     @State private var selectedChatModel: Model = .gpt4_o_mini
     var availableAssistants: [Assistant]
 
-    private static let availableChatModels: [Model] = [.gpt3_5Turbo, .gpt4]
+    private static let availableChatModels: [Model] = [.gpt4_o_mini]
 
     let conversation: Conversation
     let error: Error?


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

This PR includes three main changes:
1. Enhanced function call handling in chat streaming by improving the data structure and accumulation logic
2. Updated the model selection in the detail view to use GPT4-O-Mini instead of GPT-3.5 Turbo and GPT-4
3. Set GPT4-O-Mini as the default model in the detail view

## Why

1. The function call handling improvements make the streaming implementation more robust and maintainable by using a dictionary-based approach that properly handles indexed function calls
2. The model changes simplify the user experience by defaulting to GPT4-O-Mini, which can be used without providing billing information to the model provider
3. Make the demo application more accessible and reliable for users who don't have billing information set up

## Affected Areas

1. Demo/DemoChat/Sources/ChatStore.swift
  1. Function call handling in streaming chat
  2. Message accumulation logic
  3. Function call output formatting
2. Demo/DemoChat/Sources/UI/DetailView.swift
  1. Model selection options
  2. Default model configuration
  3. Available models list
