### PR TITLE
Make `ModelResult/created` optional

### DIFF
--- a/Sources/OpenAI/Public/Models/Models/ModelResult.swift
+++ b/Sources/OpenAI/Public/Models/Models/ModelResult.swift
@@ -13,7 +13,7 @@ public struct ModelResult: Codable, Equatable {
     /// The model identifier, which can be referenced in the API endpoints.
     public let id: String
     /// The Unix timestamp (in seconds) when the model was created.
-    public let created: TimeInterval
+    public let created: TimeInterval?
     /// The object type, which is always "model".
     public let object: String
     /// The organization that owns the model.


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

This PR makes the `created` field on `ModelResult` optional.

## Why

Google AI Studio doesn't support the `created` field on `Model`, which is why listing models fails.

## Affected Areas

Only the `created` field of `ModelResult` is modified. This is technically a breaking change.
