### PR TITLE
Handle HTTP status errors in streaming sessions

### DIFF
--- a/Sources/OpenAI/Public/Errors/APIError.swift
+++ b/Sources/OpenAI/Public/Errors/APIError.swift
@@ -7,8 +7,13 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 public enum OpenAIError: Error {
     case emptyData
+    case statusError(response: HTTPURLResponse, statusCode: Int)
 }
 
 public struct APIError: Error, Decodable, Equatable {


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

This PR adds proper HTTP error handling to `StreamingSession`, and exposes access to both the `HTTPURLResponse` as well as the `statusCode` via `OpenAIError/statusError`.

## Why

HTTP status errors (404, 500, etc.) aren't currently handled in streaming sessions. Instead, if an error is encountered, the streaming session simply terminates without yielding any chunks, which is very much unexpected.

## Affected Areas

This is simply an additional delegate method implementation on `StreamingSession` (`urlSession(session:dataTask:didReceive:completionHandler:)`), and it's _mostly_ an internal change that's transparent to users.

Users should already be handling `OpenAIError` anyway, so hopefully this shouldn't cause any unexpected behavior for anyone. Personally, I would not consider this a breaking change.