### PR TITLE
Feat: support gpt-4o-mini-tts model and new speech params

### DIFF
--- a/Sources/OpenAI/Public/Models/AudioSpeechQuery.swift
+++ b/Sources/OpenAI/Public/Models/AudioSpeechQuery.swift
@@ -36,12 +36,14 @@ public struct AudioSpeechQuery: Codable, Sendable {
     /// -  opus
     /// -  aac
     /// -  flac
+    /// -  wav
     /// -  pcm
     public enum AudioSpeechResponseFormat: String, Codable, CaseIterable, Sendable {
         case mp3
         case opus
         case aac
         case flac
+        case wav
         case pcm
     }
     /// The text to generate audio for. The maximum length is 4096 characters.
@@ -57,30 +59,34 @@ public struct AudioSpeechQuery: Codable, Sendable {
     /// The speed of the generated audio. Select a value from **0.25** to **4.0**. **1.0** is the default.
     /// Defaults to 1
     public let speed: Double?
-    
+    ///  Control the voice of your generated audio with additional instructions. Does not work with tts-1 or tts-1-hd.
+    public let instructions: String?
+
     public enum CodingKeys: String, CodingKey {
         case model
         case input
         case voice
         case responseFormat = "response_format"
         case speed
+        case instructions
     }
 
-    public init(model: Model, input: String, voice: AudioSpeechVoice, responseFormat: AudioSpeechResponseFormat = .mp3, speed: Double = 1.0) {
+    public init(model: Model, input: String, voice: AudioSpeechVoice, instructions: String = "", responseFormat: AudioSpeechResponseFormat = .mp3, speed: Double = 1.0) {
         self.model = AudioSpeechQuery.validateSpeechModel(model)
         self.speed = AudioSpeechQuery.normalizeSpeechSpeed(speed)
         self.input = input
         self.voice = voice
         self.responseFormat = responseFormat
+        self.instructions = instructions
     }
 }
 
 private extension AudioSpeechQuery {
     
     static func validateSpeechModel(_ inputModel: Model) -> Model {
-        let isModelOfIncorrentFormat = inputModel != .tts_1 && inputModel != .tts_1_hd
+        let isModelOfIncorrentFormat = inputModel != .tts_1 && inputModel != .tts_1_hd && inputModel != .gpt_4o_mini_tts
         guard !isModelOfIncorrentFormat else {
-            print("[AudioSpeech] 'AudioSpeechQuery' must have a valid Text-To-Speech model, 'tts-1' or 'tts-1-hd'. Setting model to 'tts-1'.")
+            print("[AudioSpeech] 'AudioSpeechQuery' must have a valid Text-To-Speech model, 'tts-1' or 'tts-1-hd', or 'gpt-4o-mini-tts'. Setting model to 'tts-1'.")
             return .tts_1
         }
         return inputModel

--- a/Sources/OpenAI/Public/Models/Models/Models.swift
+++ b/Sources/OpenAI/Public/Models/Models/Models.swift
@@ -99,10 +99,11 @@ public extension Model {
     static let gpt3_5Turbo_16k_0613 = "gpt-3.5-turbo-16k-0613"
     
     // Speech
-    
-    /// The latest text to speech model, optimized for speed.
+    /// A text-to-speech model built on GPT-4o mini, a fast and powerful language model.
+    static let gpt_4o_mini_tts = "gpt-4o-mini-tts"
+    /// tts-1 model is optimized for realtime text-to-speech use cases
     static let tts_1 = "tts-1"
-    /// The latest text to speech model, optimized for quality.
+    /// tts-1-hd model is optimized for high quality text-to-speech use cases.
     static let tts_1_hd = "tts-1-hd"
     
     // Transcriptions / Translations


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

https://platform.openai.com/docs/api-reference/audio/createSpeech

1. Support new [TTS model](https://platform.openai.com/docs/models#tts): gpt-4o-mini-tts
2. Support `instructions` in `AudioSpeechQuery`, which control the voice of your generated audio with additional instructions. 
3. Support response_format `wav`.


## Why

OpenAI just released [new audio-models](https://openai.com/index/introducing-our-next-generation-audio-models/)

## Affected Areas

AudioSpeechQuery

<!-- Please describe what parts of the library are affected by the change -->
