### PR TITLE
Add Middlewares

### DIFF
--- a/Sources/OpenAI/OpenAI+OpenAIAsync.swift
+++ b/Sources/OpenAI/OpenAI+OpenAIAsync.swift
@@ -218,9 +218,9 @@ extension OpenAI: OpenAIAsync {
             }
             let decoder = JSONDecoder()
             do {
-                return try decoder.decode(ResultType.self, from: interceptedData ?? Data())
+                return try decoder.decode(ResultType.self, from: interceptedData ?? data)
             } catch {
-                throw (try? decoder.decode(APIErrorResponse.self, from: interceptedData ?? Data())) ?? error
+                throw (try? decoder.decode(APIErrorResponse.self, from: interceptedData ?? data)) ?? error
             }
         } else {
             let dataTaskStore = URLSessionDataTaskStore()
@@ -254,7 +254,7 @@ extension OpenAI: OpenAIAsync {
             let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
                 middleware.intercept(response: current.response, data: current.data)
             }
-            return .init(audio: interceptedData ?? Data())
+            return .init(audio: interceptedData ?? data)
         } else {
             let dataTaskStore = URLSessionDataTaskStore()
             return try await withTaskCancellationHandler {

--- a/Sources/OpenAI/OpenAI+OpenAIAsync.swift
+++ b/Sources/OpenAI/OpenAI+OpenAIAsync.swift
@@ -207,20 +207,26 @@ extension OpenAI: OpenAIAsync {
     
     func performRequestAsync<ResultType: Codable & Sendable>(request: any URLRequestBuildable) async throws -> ResultType {
         let urlRequest = try request.build(configuration: configuration)
-        
+        let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
+            middleware.intercept(request: current)
+        }
+
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            let (data, _) = try await session.data(for: urlRequest, delegate: nil)
+            let (data, response) = try await session.data(for: interceptedRequest, delegate: nil)
+            let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
+                middleware.intercept(response: current.response, data: current.data)
+            }
             let decoder = JSONDecoder()
             do {
-                return try decoder.decode(ResultType.self, from: data)
+                return try decoder.decode(ResultType.self, from: interceptedData ?? Data())
             } catch {
-                throw (try? decoder.decode(APIErrorResponse.self, from: data)) ?? error
+                throw (try? decoder.decode(APIErrorResponse.self, from: interceptedData ?? Data())) ?? error
             }
         } else {
             let dataTaskStore = URLSessionDataTaskStore()
             return try await withTaskCancellationHandler {
                 return try await withCheckedThrowingContinuation { continuation in
-                    let dataTask = self.makeDataTask(forRequest: urlRequest) { (result: Result<ResultType, Error>) in
+                    let dataTask = self.makeDataTask(forRequest: interceptedRequest) { (result: Result<ResultType, Error>) in
                         continuation.resume(with: result)
                     }
                     
@@ -240,14 +246,20 @@ extension OpenAI: OpenAIAsync {
     
     func performSpeechRequestAsync(request: any URLRequestBuildable) async throws -> AudioSpeechResult {
         let urlRequest = try request.build(configuration: configuration)
+        let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
+            middleware.intercept(request: current)
+        }
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            let (data, _) = try await session.data(for: urlRequest, delegate: nil)
-            return .init(audio: data)
+            let (data, response) = try await session.data(for: interceptedRequest, delegate: nil)
+            let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
+                middleware.intercept(response: current.response, data: current.data)
+            }
+            return .init(audio: interceptedData ?? Data())
         } else {
             let dataTaskStore = URLSessionDataTaskStore()
             return try await withTaskCancellationHandler {
                 return try await withCheckedThrowingContinuation { continuation in
-                    let dataTask = self.makeRawResponseDataTask(forRequest: urlRequest) { result in
+                    let dataTask = self.makeRawResponseDataTask(forRequest: interceptedRequest) { result in
                         switch result {
                         case .success(let success):
                             continuation.resume(returning: .init(audio: success))

--- a/Sources/OpenAI/OpenAI+OpenAIAsync.swift
+++ b/Sources/OpenAI/OpenAI+OpenAIAsync.swift
@@ -214,7 +214,7 @@ extension OpenAI: OpenAIAsync {
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             let (data, response) = try await session.data(for: interceptedRequest, delegate: nil)
             let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
-                middleware.intercept(response: current.response, data: current.data)
+                middleware.intercept(response: current.response, request: urlRequest, data: current.data)
             }
             let decoder = JSONDecoder()
             do {
@@ -252,7 +252,7 @@ extension OpenAI: OpenAIAsync {
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             let (data, response) = try await session.data(for: interceptedRequest, delegate: nil)
             let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
-                middleware.intercept(response: current.response, data: current.data)
+                middleware.intercept(response: current.response, request: urlRequest, data: current.data)
             }
             return .init(audio: interceptedData ?? data)
         } else {

--- a/Sources/OpenAI/OpenAI+OpenAICombine.swift
+++ b/Sources/OpenAI/OpenAI+OpenAICombine.swift
@@ -205,16 +205,22 @@ extension OpenAI: OpenAICombine {
     
     func performRequestCombine<ResultType: Codable>(request: any URLRequestBuildable) -> AnyPublisher<ResultType, Error> {
         do {
-            let request = try request.build(configuration: configuration)
-            
+            let urlRequest = try request.build(configuration: configuration)
+            let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
+                middleware.intercept(request: current)
+            }
+
             return session
-                .dataTaskPublisher(for: request)
+                .dataTaskPublisher(for: interceptedRequest)
                 .tryMap { (data, response) in
                     let decoder = JSONDecoder()
+                    let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
+                        middleware.intercept(response: current.response, data: current.data)
+                    }
                     do {
-                        return try decoder.decode(ResultType.self, from: data)
+                        return try decoder.decode(ResultType.self, from: interceptedData ?? Data())
                     } catch {
-                        throw (try? decoder.decode(APIErrorResponse.self, from: data)) ?? error
+                        throw (try? decoder.decode(APIErrorResponse.self, from: interceptedData ?? Data())) ?? error
                     }
                 }.eraseToAnyPublisher()
         } catch {
@@ -225,11 +231,17 @@ extension OpenAI: OpenAICombine {
     
     func performSpeechRequestCombine(request: any URLRequestBuildable) -> AnyPublisher<AudioSpeechResult, Error> {
         do {
-            let request = try request.build(configuration: configuration)
+            let urlRequest = try request.build(configuration: configuration)
+            let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
+                middleware.intercept(request: current)
+            }
             return session
-                .dataTaskPublisher(for: request)
+                .dataTaskPublisher(for: interceptedRequest)
                 .tryMap { (data, response) in
-                    return .init(audio: data)
+                    let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
+                        middleware.intercept(response: current.response, data: current.data)
+                    }
+                    return .init(audio: interceptedData ?? Data())
                 }.eraseToAnyPublisher()
         } catch {
             return Fail(outputType: AudioSpeechResult.self, failure: error)

--- a/Sources/OpenAI/OpenAI+OpenAICombine.swift
+++ b/Sources/OpenAI/OpenAI+OpenAICombine.swift
@@ -215,7 +215,7 @@ extension OpenAI: OpenAICombine {
                 .tryMap { (data, response) in
                     let decoder = JSONDecoder()
                     let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
-                        middleware.intercept(response: current.response, data: current.data)
+                        middleware.intercept(response: current.response, request: urlRequest, data: current.data)
                     }
                     do {
                         return try decoder.decode(ResultType.self, from: interceptedData ?? data)
@@ -239,7 +239,7 @@ extension OpenAI: OpenAICombine {
                 .dataTaskPublisher(for: interceptedRequest)
                 .tryMap { (data, response) in
                     let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
-                        middleware.intercept(response: current.response, data: current.data)
+                        middleware.intercept(response: current.response, request: urlRequest, data: current.data)
                     }
                     return .init(audio: interceptedData ?? data)
                 }.eraseToAnyPublisher()

--- a/Sources/OpenAI/OpenAI+OpenAICombine.swift
+++ b/Sources/OpenAI/OpenAI+OpenAICombine.swift
@@ -218,9 +218,9 @@ extension OpenAI: OpenAICombine {
                         middleware.intercept(response: current.response, data: current.data)
                     }
                     do {
-                        return try decoder.decode(ResultType.self, from: interceptedData ?? Data())
+                        return try decoder.decode(ResultType.self, from: interceptedData ?? data)
                     } catch {
-                        throw (try? decoder.decode(APIErrorResponse.self, from: interceptedData ?? Data())) ?? error
+                        throw (try? decoder.decode(APIErrorResponse.self, from: interceptedData ?? data)) ?? error
                     }
                 }.eraseToAnyPublisher()
         } catch {
@@ -241,7 +241,7 @@ extension OpenAI: OpenAICombine {
                     let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
                         middleware.intercept(response: current.response, data: current.data)
                     }
-                    return .init(audio: interceptedData ?? Data())
+                    return .init(audio: interceptedData ?? data)
                 }.eraseToAnyPublisher()
         } catch {
             return Fail(outputType: AudioSpeechResult.self, failure: error)

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -339,7 +339,7 @@ extension OpenAI {
                     return completion(.failure(error))
                 }
                 let (_, data) = self.middlewares.reduce((response, data)) { current, middleware in
-                    middleware.intercept(response: current.response, data: current.data)
+                    middleware.intercept(response: current.response, request: urlRequest, data: current.data)
                 }
                 guard let data else {
                     return completion(.failure(OpenAIError.emptyData))
@@ -391,7 +391,7 @@ extension OpenAI {
                 return completion(.failure(error))
             }
             let (_, data) = self.middlewares.reduce((response, data)) { current, middleware in
-                middleware.intercept(response: current.response, data: current.data)
+                middleware.intercept(response: current.response, request: request, data: current.data)
             }
             guard let data else {
                 return completion(.failure(OpenAIError.emptyData))
@@ -411,7 +411,7 @@ extension OpenAI {
                 return completion(.failure(error))
             }
             let (_, data) = self.middlewares.reduce((response, data)) { current, middleware in
-                middleware.intercept(response: current.response, data: current.data)
+                middleware.intercept(response: current.response, request: request, data: current.data)
             }
             guard let data else {
                 return completion(.failure(OpenAIError.emptyData))

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -58,7 +58,8 @@ final public class OpenAI: @unchecked Sendable {
     }
     
     let session: URLSessionProtocol
-    
+    let middlewares: [OpenAIMiddleware]
+
     private let streamingSessionFactory: StreamingSessionFactory
     private let cancellablesFactory: CancellablesFactory
     private let executionSerializer: ExecutionSerializer
@@ -67,20 +68,36 @@ final public class OpenAI: @unchecked Sendable {
     public let configuration: Configuration
 
     public convenience init(apiToken: String) {
-        self.init(configuration: Configuration(token: apiToken), session: URLSession.shared, sslStreamingDelegate: nil)
+        self.init(
+            configuration: Configuration(token: apiToken),
+            session: URLSession.shared,
+            middlewares: [],
+            sslStreamingDelegate: nil
+        )
     }
     
     public convenience init(configuration: Configuration) {
-        self.init(configuration: configuration, session: URLSession.shared, sslStreamingDelegate: nil)
+        self.init(
+            configuration: configuration,
+            session: URLSession.shared,
+            middlewares: [],
+            sslStreamingDelegate: nil
+        )
     }
     
-    public convenience init(configuration: Configuration, session: URLSession = URLSession.shared, sslStreamingDelegate: SSLDelegateProtocol? = nil) {
+    public convenience init(
+        configuration: Configuration,
+        session: URLSession = URLSession.shared,
+        middlewares: [OpenAIMiddleware] = [],
+        sslStreamingDelegate: SSLDelegateProtocol? = nil
+    ) {
         let streamingSessionFactory = ImplicitURLSessionStreamingSessionFactory(sslDelegate: sslStreamingDelegate)
         
         self.init(
             configuration: configuration,
             session: session,
-            streamingSessionFactory: streamingSessionFactory
+            streamingSessionFactory: streamingSessionFactory,
+            middlewares: middlewares
         )
     }
 
@@ -89,13 +106,15 @@ final public class OpenAI: @unchecked Sendable {
         session: URLSessionProtocol,
         streamingSessionFactory: StreamingSessionFactory,
         cancellablesFactory: CancellablesFactory = DefaultCancellablesFactory(),
-        executionSerializer: ExecutionSerializer = GCDQueueAsyncExecutionSerializer(queue: .userInitiated)
+        executionSerializer: ExecutionSerializer = GCDQueueAsyncExecutionSerializer(queue: .userInitiated),
+        middlewares: [OpenAIMiddleware] = []
     ) {
         self.configuration = configuration
         self.session = session
         self.streamingSessionFactory = streamingSessionFactory
         self.cancellablesFactory = cancellablesFactory
         self.executionSerializer = executionSerializer
+        self.middlewares = middlewares
     }
     
     public func threadsAddMessage(
@@ -265,8 +284,11 @@ final public class OpenAI: @unchecked Sendable {
 extension OpenAI {
     func performRequest<ResultType: Codable>(request: any URLRequestBuildable, completion: @escaping @Sendable (Result<ResultType, Error>) -> Void) -> CancellableRequest {
         do {
-            let request = try request.build(configuration: configuration)
-            let task = makeDataTask(forRequest: request, completion: completion)
+            let urlRequest = try request.build(configuration: configuration)
+            let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
+                middleware.intercept(request: current)
+            }
+            let task = makeDataTask(forRequest: interceptedRequest, completion: completion)
             task.resume()
             return cancellablesFactory.makeTaskCanceller(task: task)
         } catch {
@@ -282,8 +304,14 @@ extension OpenAI {
     ) -> CancellableRequest {
         do {
             let urlRequest = try request.build(configuration: configuration)
-            
-            let session = streamingSessionFactory.makeServerSentEventsStreamingSession(urlRequest: urlRequest) { _, object in
+            let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
+                middleware.intercept(request: current)
+            }
+
+            let session = streamingSessionFactory.makeServerSentEventsStreamingSession(
+                urlRequest: interceptedRequest,
+                middlewares: middlewares
+            ) { _, object in
                 onResult(.success(object))
             } onProcessingError: { _, error in
                 onResult(.failure(error))
@@ -301,13 +329,19 @@ extension OpenAI {
     
     func performSpeechRequest(request: any URLRequestBuildable, completion: @escaping @Sendable (Result<AudioSpeechResult, Error>) -> Void) -> CancellableRequest {
         do {
-            let request = try request.build(configuration: configuration)
-            
-            let task = session.dataTask(with: request) { data, _, error in
-                if let error = error {
+            let urlRequest = try request.build(configuration: configuration)
+            let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
+                middleware.intercept(request: current)
+            }
+
+            let task = session.dataTask(with: interceptedRequest) { data, response, error in
+                if let error {
                     return completion(.failure(error))
                 }
-                guard let data = data else {
+                let (_, data) = self.middlewares.reduce((response, data)) { current, middleware in
+                    middleware.intercept(response: current.response, data: current.data)
+                }
+                guard let data else {
                     return completion(.failure(OpenAIError.emptyData))
                 }
                 
@@ -328,8 +362,14 @@ extension OpenAI {
     ) -> CancellableRequest {
         do {
             let urlRequest = try request.build(configuration: configuration)
-            
-            let session = streamingSessionFactory.makeAudioSpeechStreamingSession(urlRequest: urlRequest) { _, object in
+            let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
+                middleware.intercept(request: current)
+            }
+
+            let session = streamingSessionFactory.makeAudioSpeechStreamingSession(
+                urlRequest: interceptedRequest,
+                middlewares: middlewares
+            ) { _, object in
                 onResult(.success(object))
             } onProcessingError: { _, error in
                 onResult(.failure(error))
@@ -346,11 +386,14 @@ extension OpenAI {
     }
     
     func makeDataTask<ResultType: Codable>(forRequest request: URLRequest, completion: @escaping @Sendable (Result<ResultType, Error>) -> Void) -> URLSessionDataTaskProtocol {
-        session.dataTask(with: request) { data, _, error in
-            if let error = error {
+        session.dataTask(with: request) { data, response, error in
+            if let error {
                 return completion(.failure(error))
             }
-            guard let data = data else {
+            let (_, data) = self.middlewares.reduce((response, data)) { current, middleware in
+                middleware.intercept(response: current.response, data: current.data)
+            }
+            guard let data else {
                 return completion(.failure(OpenAIError.emptyData))
             }
             let decoder = JSONDecoder()
@@ -363,11 +406,14 @@ extension OpenAI {
     }
     
     func makeRawResponseDataTask(forRequest request: URLRequest, completion: @escaping @Sendable (Result<Data, Error>) -> Void) -> URLSessionDataTaskProtocol {
-        session.dataTask(with: request) { data, _, error in
-            if let error = error {
+        session.dataTask(with: request) { data, response, error in
+            if let error {
                 return completion(.failure(error))
             }
-            guard let data = data else {
+            let (_, data) = self.middlewares.reduce((response, data)) { current, middleware in
+                middleware.intercept(response: current.response, data: current.data)
+            }
+            guard let data else {
                 return completion(.failure(OpenAIError.emptyData))
             }
             

--- a/Sources/OpenAI/Private/Streaming/ServerSentEventsStreamingSessionFactory.swift
+++ b/Sources/OpenAI/Private/Streaming/ServerSentEventsStreamingSessionFactory.swift
@@ -14,6 +14,7 @@ import FoundationNetworking
 protocol StreamingSessionFactory {
     func makeServerSentEventsStreamingSession<ResultType: Codable & Sendable>(
         urlRequest: URLRequest,
+        middlewares: [OpenAIMiddleware],
         onReceiveContent: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, ResultType) -> Void,
         onProcessingError: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, Error) -> Void,
         onComplete: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, Error?) -> Void
@@ -21,6 +22,7 @@ protocol StreamingSessionFactory {
     
     func makeAudioSpeechStreamingSession(
         urlRequest: URLRequest,
+        middlewares: [OpenAIMiddleware],
         onReceiveContent: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, AudioSpeechResult) -> Void,
         onProcessingError: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, Error) -> Void,
         onComplete: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, Error?) -> Void
@@ -32,6 +34,7 @@ struct ImplicitURLSessionStreamingSessionFactory: StreamingSessionFactory {
     
     func makeServerSentEventsStreamingSession<ResultType>(
         urlRequest: URLRequest,
+        middlewares: [OpenAIMiddleware],
         onReceiveContent: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, ResultType) -> Void,
         onProcessingError: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, any Error) -> Void,
         onComplete: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, (any Error)?) -> Void
@@ -40,6 +43,7 @@ struct ImplicitURLSessionStreamingSessionFactory: StreamingSessionFactory {
             urlRequest: urlRequest,
             interpreter: .init(),
             sslDelegate: sslDelegate,
+            middlewares: middlewares,
             onReceiveContent: onReceiveContent,
             onProcessingError: onProcessingError,
             onComplete: onComplete
@@ -48,6 +52,7 @@ struct ImplicitURLSessionStreamingSessionFactory: StreamingSessionFactory {
     
     func makeAudioSpeechStreamingSession(
         urlRequest: URLRequest,
+        middlewares: [OpenAIMiddleware],
         onReceiveContent: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, AudioSpeechResult) -> Void,
         onProcessingError: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, any Error) -> Void,
         onComplete: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, (any Error)?) -> Void
@@ -56,6 +61,7 @@ struct ImplicitURLSessionStreamingSessionFactory: StreamingSessionFactory {
             urlRequest: urlRequest,
             interpreter: .init(),
             sslDelegate: sslDelegate,
+            middlewares: middlewares,
             onReceiveContent: onReceiveContent,
             onProcessingError: onProcessingError,
             onComplete: onComplete

--- a/Sources/OpenAI/Private/Streaming/StreamingSession.swift
+++ b/Sources/OpenAI/Private/Streaming/StreamingSession.swift
@@ -56,7 +56,7 @@ final class StreamingSession<Interpreter: StreamInterpreter>: NSObject, Identifi
     
     func urlSession(_ session: any URLSessionProtocol, dataTask: any URLSessionDataTaskProtocol, didReceive data: Data) {
         let data = self.middlewares.reduce(data) { current, middleware in
-            middleware.interceptStreamingData(current)
+            middleware.interceptStreamingData(request: dataTask.originalRequest, current)
         }
         interpreter.processData(data)
     }

--- a/Sources/OpenAI/Private/Streaming/StreamingSession.swift
+++ b/Sources/OpenAI/Private/Streaming/StreamingSession.swift
@@ -21,12 +21,14 @@ final class StreamingSession<Interpreter: StreamInterpreter>: NSObject, Identifi
     private let onComplete: (@Sendable (StreamingSession, Error?) -> Void)?
     private let interpreter: Interpreter
     private let sslDelegate: SSLDelegateProtocol?
-    
+    private let middlewares: [OpenAIMiddleware]
+
     init(
         urlSessionFactory: URLSessionFactory = FoundationURLSessionFactory(),
         urlRequest: URLRequest,
         interpreter: Interpreter,
         sslDelegate: SSLDelegateProtocol?,
+        middlewares: [OpenAIMiddleware],
         onReceiveContent: @escaping @Sendable (StreamingSession, ResultType) -> Void,
         onProcessingError: @escaping @Sendable (StreamingSession, Error) -> Void,
         onComplete: @escaping @Sendable (StreamingSession, Error?) -> Void
@@ -35,6 +37,7 @@ final class StreamingSession<Interpreter: StreamInterpreter>: NSObject, Identifi
         self.urlRequest = urlRequest
         self.interpreter = interpreter
         self.sslDelegate = sslDelegate
+        self.middlewares = middlewares
         self.onReceiveContent = onReceiveContent
         self.onProcessingError = onProcessingError
         self.onComplete = onComplete
@@ -52,6 +55,9 @@ final class StreamingSession<Interpreter: StreamInterpreter>: NSObject, Identifi
     }
     
     func urlSession(_ session: any URLSessionProtocol, dataTask: any URLSessionDataTaskProtocol, didReceive data: Data) {
+        let data = self.middlewares.reduce((data)) { current, middleware in
+            middleware.interceptStreamingData(current)
+        }
         interpreter.processData(data)
     }
 

--- a/Sources/OpenAI/Private/Streaming/StreamingSession.swift
+++ b/Sources/OpenAI/Private/Streaming/StreamingSession.swift
@@ -55,7 +55,7 @@ final class StreamingSession<Interpreter: StreamInterpreter>: NSObject, Identifi
     }
     
     func urlSession(_ session: any URLSessionProtocol, dataTask: any URLSessionDataTaskProtocol, didReceive data: Data) {
-        let data = self.middlewares.reduce((data)) { current, middleware in
+        let data = self.middlewares.reduce(data) { current, middleware in
             middleware.interceptStreamingData(current)
         }
         interpreter.processData(data)

--- a/Sources/OpenAI/Private/URLSessionDataTaskProtocol.swift
+++ b/Sources/OpenAI/Private/URLSessionDataTaskProtocol.swift
@@ -11,6 +11,7 @@ import FoundationNetworking
 #endif
 
 protocol URLSessionTaskProtocol: Sendable {
+    var originalRequest: URLRequest? { get }
     func cancel()
 }
 

--- a/Sources/OpenAI/Public/Protocols/OpenAIMiddleware.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIMiddleware.swift
@@ -6,11 +6,11 @@ import FoundationNetworking
 public protocol OpenAIMiddleware: Sendable {
     func intercept(request: URLRequest) -> URLRequest
     func interceptStreamingData(request: URLRequest?, _ data: Data) -> Data
-    func intercept(response: URLResponse?, data: Data?) -> (response: URLResponse?, data: Data?)
+    func intercept(response: URLResponse?, request: URLRequest, data: Data?) -> (response: URLResponse?, data: Data?)
 }
 
 public extension OpenAIMiddleware {
     func intercept(request: URLRequest) -> URLRequest { request }
     func interceptStreamingData(request: URLRequest?, _ data: Data) -> Data { data }
-    func intercept(response: URLResponse?, data: Data?) -> (response: URLResponse?, data: Data?) { (response, data) }
+    func intercept(response: URLResponse?, request: URLRequest, data: Data?) -> (response: URLResponse?, data: Data?) { (response, data) }
 }

--- a/Sources/OpenAI/Public/Protocols/OpenAIMiddleware.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIMiddleware.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public protocol OpenAIMiddleware: Sendable {
+    func intercept(request: URLRequest) -> URLRequest
+    func interceptStreamingData(_ data: Data) -> Data
+    func intercept(response: URLResponse?, data: Data?) -> (response: URLResponse?, data: Data?)
+}
+
+public extension OpenAIMiddleware {
+    func intercept(request: URLRequest) -> URLRequest { request }
+    func interceptStreamingData(_ data: Data) -> Data { data }
+    func intercept(response: URLResponse?, data: Data?) -> (response: URLResponse?, data: Data?) { (response, data) }
+}

--- a/Sources/OpenAI/Public/Protocols/OpenAIMiddleware.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIMiddleware.swift
@@ -1,13 +1,16 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol OpenAIMiddleware: Sendable {
     func intercept(request: URLRequest) -> URLRequest
-    func interceptStreamingData(_ data: Data) -> Data
+    func interceptStreamingData(request: URLRequest?, _ data: Data) -> Data
     func intercept(response: URLResponse?, data: Data?) -> (response: URLResponse?, data: Data?)
 }
 
 public extension OpenAIMiddleware {
     func intercept(request: URLRequest) -> URLRequest { request }
-    func interceptStreamingData(_ data: Data) -> Data { data }
+    func interceptStreamingData(request: URLRequest?, _ data: Data) -> Data { data }
     func intercept(response: URLResponse?, data: Data?) -> (response: URLResponse?, data: Data?) { (response, data) }
 }

--- a/Tests/OpenAITests/Mocks/DataTaskMock.swift
+++ b/Tests/OpenAITests/Mocks/DataTaskMock.swift
@@ -17,7 +17,8 @@ class DataTaskMock: URLSessionDataTaskProtocol, @unchecked Sendable {
     var response: URLResponse?
     var error: Error?
     var urlError: URLError? // Needed for mocking combine dataTaskPublisher
-    
+    var originalRequest: URLRequest?
+
     var completion: ((Data?, URLResponse?, Error?) -> Void)?
     
     func resume() {

--- a/Tests/OpenAITests/Mocks/MockStreamingSessionFactory.swift
+++ b/Tests/OpenAITests/Mocks/MockStreamingSessionFactory.swift
@@ -17,6 +17,7 @@ class MockStreamingSessionFactory: StreamingSessionFactory {
     
     func makeServerSentEventsStreamingSession<ResultType>(
         urlRequest: URLRequest,
+        middlewares: [OpenAIMiddleware],
         onReceiveContent: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, ResultType) -> Void,
         onProcessingError: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, any Error) -> Void,
         onComplete: @Sendable @escaping (StreamingSession<ServerSentEventsStreamInterpreter<ResultType>>, (any Error)?) -> Void
@@ -26,6 +27,7 @@ class MockStreamingSessionFactory: StreamingSessionFactory {
             urlRequest: urlRequest,
             interpreter: .init(executionSerializer: NoDispatchExecutionSerializer()),
             sslDelegate: nil,
+            middlewares: middlewares,
             onReceiveContent: onReceiveContent,
             onProcessingError: onProcessingError,
             onComplete: onComplete
@@ -34,6 +36,7 @@ class MockStreamingSessionFactory: StreamingSessionFactory {
     
     func makeAudioSpeechStreamingSession(
         urlRequest: URLRequest,
+        middlewares: [OpenAIMiddleware],
         onReceiveContent: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, AudioSpeechResult) -> Void,
         onProcessingError: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, any Error) -> Void,
         onComplete: @Sendable @escaping (StreamingSession<AudioSpeechStreamInterpreter>, (any Error)?) -> Void
@@ -43,6 +46,7 @@ class MockStreamingSessionFactory: StreamingSessionFactory {
             urlRequest: urlRequest,
             interpreter: .init(),
             sslDelegate: nil,
+            middlewares: middlewares,
             onReceiveContent: onReceiveContent,
             onProcessingError: onProcessingError,
             onComplete: onComplete

--- a/Tests/OpenAITests/StreamingSessionTests.swift
+++ b/Tests/OpenAITests/StreamingSessionTests.swift
@@ -18,6 +18,7 @@ final class StreamingSessionTests: XCTestCase {
         urlRequest: .init(url: .init(string: "/")!),
         interpreter: streamInterpreter,
         sslDelegate: nil,
+        middlewares: [],
         onReceiveContent: { _, _ in
             Task {
                 await MainActor.run {


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What
Added middleware support to the OpenAI class. Middleware can be passed via the initializer and used to modify URLRequest before sending and URLResponse/Data after receiving.

## Why
This enables flexible request/response interception for use cases like logging, debugging, or analytics. For example, you can inject custom headers into requests or modify responses before they are passed to the completion handler.

## Affected Areas

Requests & responses
