### PR TITLE
Make model fields for tools and chat optional

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatResult.swift
@@ -178,7 +178,7 @@ public struct ChatResult: Codable, Equatable, Sendable {
     }
 
     /// A unique identifier for the chat completion.
-    public let id: String
+    public let id: String?
     /// The Unix timestamp (in seconds) of when the chat completion was created.
     public let created: Int
     /// The model used for the chat completion.
@@ -189,7 +189,7 @@ public struct ChatResult: Codable, Equatable, Sendable {
     public let serviceTier: String?
     /// This fingerprint represents the backend configuration that the model runs with.
     /// Can be used in conjunction with the seed request parameter to understand when backend changes have been made that might impact determinism.
-    public let systemFingerprint: String
+    public let systemFingerprint: String?
     /// A list of chat completion choices. Can be more than one if n is greater than 1.
     public let choices: [Choice]
     /// Usage statistics for the completion request.

--- a/Sources/OpenAI/Public/Models/ChatStreamResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatStreamResult.swift
@@ -121,7 +121,7 @@ public struct ChatStreamResult: Codable, Equatable, Sendable {
     }
 
     /// A unique identifier for the chat completion. Each chunk has the same ID.
-    public let id: String
+    public let id: String?
     /// The object type, which is always `chat.completion.chunk`.
     public let object: String
     /// The Unix timestamp (in seconds) of when the chat completion was created.


### PR DESCRIPTION
## What

Makes the id and finger print fields optional so that other model providers can be used.

## Why

As discussed in #283 there are other model providers that this library should support as most of them are OpenAI compatible. Unfortunately, the vendors do not follow the spec 1:1.

## Affected Areas

Doesn't match OpenAI's spec 1:1. These fields are not client values or atleast I've never had to use the `id` or `system_fingerprint` and I believe they are more for backend related functionality.
