### PR TITLE
Fix call order and write more tests

### DIFF
--- a/Sources/OpenAI/Public/Models/Models/Models.swift
+++ b/Sources/OpenAI/Public/Models/Models/Models.swift
@@ -28,6 +28,9 @@ public extension Model {
 
     /// `gpt-4o`, currently the most advanced, multimodal flagship model that's cheaper and faster than GPT-4 Turbo.
     static let gpt4_o = "gpt-4o"
+    
+    /// `gpt-4o-mini`, currently the most affordable and intelligent model for fast and lightweight requests.
+    static let gpt4_o_mini = "gpt-4o-mini"
 
     /// `gpt-4o-audio-preview`, this is a preview release of the GPT-4o Audio models. These models accept audio inputs and outputs, and can be used in the Chat Completions REST API.
     static let gpt_4o_audio_preview = "gpt-4o-audio-preview"

--- a/Tests/OpenAITests/Mocks/WorkSimulatingMockMiddleware.swift
+++ b/Tests/OpenAITests/Mocks/WorkSimulatingMockMiddleware.swift
@@ -1,0 +1,37 @@
+//
+//  WorkSimulatingMockMiddleware.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 31.03.2025.
+//
+
+import XCTest
+@testable import OpenAI
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct WorkSimulatingMockMiddleware: OpenAIMiddleware {
+    func intercept(request: URLRequest) -> URLRequest {
+        simulateBusyThread(duration: 0.1)
+        return request
+    }
+    
+    func interceptStreamingData(request: URLRequest?, _ data: Data) -> Data {
+        simulateBusyThread(duration: 0.1)
+        return data
+    }
+    
+    func intercept(response: URLResponse?, request: URLRequest, data: Data?) -> (response: URLResponse?, data: Data?) {
+        simulateBusyThread(duration: 0.1)
+        return (response, data)
+    }
+    
+    private func simulateBusyThread(duration: TimeInterval) {
+        let end = Date().addingTimeInterval(duration)
+        while Date() < end {
+            _ = UUID().uuidString.hashValue  // Some pointless work
+        }
+    }
+}

--- a/Tests/OpenAITests/StreamingSessionIntegrationTests.swift
+++ b/Tests/OpenAITests/StreamingSessionIntegrationTests.swift
@@ -103,26 +103,4 @@ final class StreamingSessionIntegrationTests: XCTestCase {
     }
 }
 
-struct WorkSimulatingMockMiddleware: OpenAIMiddleware {
-    func intercept(request: URLRequest) -> URLRequest {
-        simulateBusyThread(duration: 0.1)
-        return request
-    }
-    
-    func interceptStreamingData(request: URLRequest?, _ data: Data) -> Data {
-        simulateBusyThread(duration: 0.1)
-        return data
-    }
-    
-    func intercept(response: URLResponse?, request: URLRequest, data: Data?) -> (response: URLResponse?, data: Data?) {
-        simulateBusyThread(duration: 0.1)
-        return (response, data)
-    }
-    
-    private func simulateBusyThread(duration: TimeInterval) {
-        let end = Date().addingTimeInterval(duration)
-        while Date() < end {
-            _ = UUID().uuidString.hashValue  // Some pointless work
-        }
-    }
-}
+


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Fix Streaming Session call order and write tests

## Why

Each call to urlSession delegate happens on a different queue. Needed to serialise keeping the correct order.
