### PR TITLE
Public init for assistant audio message.

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatQuery.swift
+++ b/Sources/OpenAI/Public/Models/ChatQuery.swift
@@ -708,6 +708,10 @@ public struct ChatQuery: Equatable, Codable, Streamable, Sendable {
 
             public struct Audio: Codable, Equatable, Sendable {
                 public let id: String
+
+                public init(id: String) {
+                    self.id = id
+                }
             }
 
             public struct ToolCallParam: Codable, Equatable, Sendable {


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Public init for assistant audio message.

## Why

Auto init is not public

## Affected Areas

ChatQuery -> ChatCompletionMessageParam -> AssistantMessageParam -> Audio
