### PR TITLE
Add parsing options for valueNotFound case

### DIFF
--- a/Sources/OpenAI/Private/KeyedDecodingContainer+ParsingOptions.swift
+++ b/Sources/OpenAI/Private/KeyedDecodingContainer+ParsingOptions.swift
@@ -27,6 +27,12 @@ extension KeyedDecodingContainer {
                 } else {
                     throw error
                 }
+            case DecodingError.valueNotFound:
+                if parsingOptions.contains(.fillRequiredFieldIfValueNotFound) {
+                    return defaultValue
+                } else {
+                    throw error
+                }
             default:
                 throw error
             }

--- a/Sources/OpenAI/Public/Utilities/ParsingOptions.swift
+++ b/Sources/OpenAI/Public/Utilities/ParsingOptions.swift
@@ -15,4 +15,7 @@ public struct ParsingOptions: OptionSet {
     }
     
     public static let fillRequiredFieldIfKeyNotFound = ParsingOptions(rawValue: 1 << 0)
+    public static let fillRequiredFieldIfValueNotFound = ParsingOptions(rawValue: 1 << 1)
+    
+    public static let relaxed: ParsingOptions = [.fillRequiredFieldIfKeyNotFound, .fillRequiredFieldIfValueNotFound]
 }

--- a/Tests/OpenAITests/ChatResultTests.swift
+++ b/Tests/OpenAITests/ChatResultTests.swift
@@ -1,0 +1,44 @@
+//
+//  ChatResultTests.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 02.04.2025.
+//
+
+import XCTest
+@testable import OpenAI
+
+final class ChatResultTests: XCTestCase {
+    private let jsonString = """
+                {
+                  "object": "chat.completion",
+                  "created": 1677652288,
+                  "model": "gpt-4",
+                  "choices": [],
+                  "system_fingerprint": null
+                }
+                """
+    
+    func testParsingWithRelaxedOptions() throws {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [.parsingOptions: ParsingOptions.relaxed]
+        let chatResult = try decoder.decode(ChatResult.self, from: jsonString.data(using: .utf8)!)
+        XCTAssertEqual(chatResult.id, "")
+        XCTAssertEqual(chatResult.systemFingerprint, "")
+    }
+    
+    func testStringParsing() throws {
+        let decoder = JSONDecoder()
+        // no relaxing options
+        XCTAssertThrowsError(try decoder.decode(ChatResult.self, from: jsonString.data(using: .utf8)!))
+    }
+    
+    func testThrowsErrorIfOptionsNotSufficient() throws {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [.parsingOptions: ParsingOptions.fillRequiredFieldIfKeyNotFound]
+        XCTAssertThrowsError(
+            try decoder.decode(ChatResult.self, from: jsonString.data(using: .utf8)!),
+            "Should throw an error because system_fingerprint:null case is not handled"
+        )
+    }
+}

--- a/Tests/OpenAITests/Mocks/ChatResult+MockJson.swift
+++ b/Tests/OpenAITests/Mocks/ChatResult+MockJson.swift
@@ -1,0 +1,36 @@
+//
+//  ChatResult+MockJson.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 02.04.2025.
+//
+
+import Foundation
+@testable import OpenAI
+
+extension ChatResult {
+    static let mockJsonString = """
+        {
+          "id": "chatcmpl-123",
+          "object": "chat.completion",
+          "created": 1677652288,
+          "model": "gpt-4",
+          "choices": [{
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "content": "Hello, world!",
+              "annotations": [],
+              "tool_calls": []
+            },
+            "finish_reason": "stop"
+          }],
+          "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21
+          },
+          "system_fingerprint": "fp_fc9f1d7035"
+        }
+        """
+}

--- a/Tests/OpenAITests/OpenAITestsDecoder.swift
+++ b/Tests/OpenAITests/OpenAITestsDecoder.swift
@@ -59,30 +59,7 @@ class OpenAITestsDecoder: XCTestCase {
     }
     
     func testChatCompletion() async throws {
-        let data = """
-        {
-          "id": "chatcmpl-123",
-          "object": "chat.completion",
-          "created": 1677652288,
-          "model": "gpt-4",
-          "choices": [{
-            "index": 0,
-            "message": {
-              "role": "assistant",
-              "content": "Hello, world!",
-              "annotations": [],
-              "tool_calls": []
-            },
-            "finish_reason": "stop"
-          }],
-          "usage": {
-            "prompt_tokens": 9,
-            "completion_tokens": 12,
-            "total_tokens": 21
-          },
-          "system_fingerprint": "fp_fc9f1d7035"
-        }
-        """
+        let data = ChatResult.mockJsonString
         
         let expectedValue = ChatResult(
             id: "chatcmpl-123", created: 1677652288, model: .gpt4, object: "chat.completion", serviceTier: nil, systemFingerprint: "fp_fc9f1d7035",


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Add `.fillRequiredFieldIfValueNotFound` to enable parsing for the cases like in the issue. Add "syntactic sugar" `.relaxed` option that combines both `keyNotFound` and `valueNotFound` options.

## Why

To support more providers, like Alibaba's Qwen

## Affected Areas

`ParsingOptions`, `extension KeyedDecodingContainer`
