### PR TITLE
Support `reasoning` in ChatStreamResult deltas

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatStreamResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatStreamResult.swift
@@ -18,12 +18,25 @@ public struct ChatStreamResult: Codable, Equatable, Sendable {
             public let content: String?
             /// If the audio output modality is requested, this object contains data about the audio response from the model.
             public let audio: ChoiceDeltaAudio?
-            /// The reasoning content of the chunk message.
-            /// Only some model are supported, like DeepSeek-R1.
-            public let reasoningContent: String?
+
             /// The role of the author of this message.
             public let role: Self.Role?
             public let toolCalls: [Self.ChoiceDeltaToolCall]?
+
+            /// Value for `reasoning` field in response.
+            ///
+            /// Provided by:
+            /// - Gemini (in OpenAI compatibility mode)
+            ///   https://github.com/MacPaw/OpenAI/issues/283#issuecomment-2711396735
+            /// - OpenRouter
+            public let reasoning: String?
+
+            /// Value for `reasoning_content` field.
+            ///
+            /// Provided by:
+            /// - Deepseek
+            ///   https://api-docs.deepseek.com/api/create-chat-completion#responses
+            public let reasoningContent: String?
 
             public struct ChoiceDeltaAudio: Codable, Equatable, Sendable {
 
@@ -85,9 +98,10 @@ public struct ChatStreamResult: Codable, Equatable, Sendable {
             public enum CodingKeys: String, CodingKey {
                 case content
                 case audio
-                case reasoningContent = "reasoning_content"
                 case role
                 case toolCalls = "tool_calls"
+                case reasoning = "reasoning"
+                case reasoningContent = "reasoning_content"
             }
         }
 


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Currently, streaming deltas only support the `reasoning_content` field. But providers such as OpenRouter (and possibly Gemini in OpenAI compatibility mode) use the `reasoning` field instead.

## Why

Support for the `reasoning` field is missing in streaming deltas.

- Support for `reasoning_content` in streaming deltas was added:
  #279
- Support for `reasoning` and `reasoning_content` in regular chat responses was added:
  #289

## Affected Areas

No breaking changes, just a new field in `ChatStreamResult.Choice.ChoiceDelta`.