### PR TITLE
Add `error` finish reason

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatResult.swift
@@ -158,6 +158,7 @@ public struct ChatResult: Codable, Equatable, Sendable {
             case toolCalls = "tool_calls"
             case contentFilter = "content_filter"
             case functionCall = "function_call"
+            case error
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

This PR adds an additional `error` finish reason.

## Why

Some inference providers, such as OpenRouter, include an `error` finish reason.

Docs: https://openrouter.ai/docs/api-reference/overview#finish-reason

## Affected Areas

`FinishReason`
