### PR TITLE
Unify `reasoning` and `reasoningContent` fields

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatResult.swift
@@ -46,18 +46,33 @@ public struct ChatResult: Codable, Equatable, Sendable {
             /// Following are fields that are not part of OpenAI but are present in responses from other providers
             
             /// Value for `reasoning` field in response.
+            ///
             /// Provided by:
-            /// Gemini (in OpenAI compatibility mode):
-            /// https://github.com/MacPaw/OpenAI/issues/283#issuecomment-2711396735
-            let reasoning: String?
-            
-            /// Value for `reasoning_content` field. Provided by:
-            /// DeepSeek: https://api-docs.deepseek.com/api/create-chat-completion#responses
-            /// "For deepseek-reasoner model only. The reasoning contents of the assistant message, before the final answer."
-            let reasoningContent: String?
-            
+            /// - Gemini (in OpenAI compatibility mode)
+            ///   https://github.com/MacPaw/OpenAI/issues/283#issuecomment-2711396735
+            /// - OpenRouter
+            internal let _reasoning: String?
+
+            /// Value for `reasoning_content` field.
+            ///
+            /// Provided by:
+            /// - Deepseek
+            ///   https://api-docs.deepseek.com/api/create-chat-completion#responses
+            internal let _reasoningContent: String?
+
+            /// Reasoning content.
+            ///
+            /// Supported response fields:
+            /// - `reasoning` (Gemini, OpenRouter)
+            /// - `reasoning_content` (Deepseek)
+            public var reasoning: String? {
+                _reasoning ?? _reasoningContent
+            }
+
             public enum CodingKeys: String, CodingKey {
-                case content, refusal, role, annotations, audio, toolCalls = "tool_calls", reasoning, reasoningContent = "reasoning_content"
+                case content, refusal, role, annotations, audio, toolCalls = "tool_calls"
+                case _reasoning = "reasoning"
+                case _reasoningContent = "reasoning_content"
             }
             
             public struct Annotation: Codable, Equatable, Sendable {

--- a/Sources/OpenAI/Public/Models/ChatStreamResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatStreamResult.swift
@@ -29,14 +29,23 @@ public struct ChatStreamResult: Codable, Equatable, Sendable {
             /// - Gemini (in OpenAI compatibility mode)
             ///   https://github.com/MacPaw/OpenAI/issues/283#issuecomment-2711396735
             /// - OpenRouter
-            public let reasoning: String?
+            internal let _reasoning: String?
 
             /// Value for `reasoning_content` field.
             ///
             /// Provided by:
             /// - Deepseek
             ///   https://api-docs.deepseek.com/api/create-chat-completion#responses
-            public let reasoningContent: String?
+            internal let _reasoningContent: String?
+
+            /// Reasoning content.
+            ///
+            /// Supported response fields:
+            /// - `reasoning` (Gemini, OpenRouter)
+            /// - `reasoning_content` (Deepseek)
+            public var reasoning: String? {
+                _reasoning ?? _reasoningContent
+            }
 
             public struct ChoiceDeltaAudio: Codable, Equatable, Sendable {
 
@@ -100,8 +109,8 @@ public struct ChatStreamResult: Codable, Equatable, Sendable {
                 case audio
                 case role
                 case toolCalls = "tool_calls"
-                case reasoning = "reasoning"
-                case reasoningContent = "reasoning_content"
+                case _reasoning = "reasoning"
+                case _reasoningContent = "reasoning_content"
             }
         }
 

--- a/Tests/OpenAITests/Extensions/ChatResult+Mock.swift
+++ b/Tests/OpenAITests/Extensions/ChatResult+Mock.swift
@@ -16,6 +16,6 @@ extension ChatResult {
     ], usage: .init(completionTokens: 200, promptTokens: 100, totalTokens: 300), citations: nil)
     
     static func mockChatResultChoiceMessage(content: String, role: String) -> ChatResult.Choice.Message {
-        .init(content: content, refusal: nil, role: role, annotations: [], audio: nil, toolCalls: [], reasoning: nil, reasoningContent: nil)
+        .init(content: content, refusal: nil, role: role, annotations: [], audio: nil, toolCalls: [], _reasoning: nil, _reasoningContent: nil)
     }
 }

--- a/Tests/OpenAITests/OpenAITestsDecoder.swift
+++ b/Tests/OpenAITests/OpenAITestsDecoder.swift
@@ -67,7 +67,7 @@ class OpenAITestsDecoder: XCTestCase {
                 .init(
                     index: 0,
                     logprobs: nil,
-                    message: .init(content: "Hello, world!", refusal: nil, role: "assistant", annotations: [], audio: nil, toolCalls: [], reasoning: nil, reasoningContent: nil),
+                    message: .init(content: "Hello, world!", refusal: nil, role: "assistant", annotations: [], audio: nil, toolCalls: [], _reasoning: nil, _reasoningContent: nil),
                     finishReason: "stop"
                 )
             ],
@@ -319,8 +319,8 @@ class OpenAITestsDecoder: XCTestCase {
                         annotations: [],
                         audio: nil,
                         toolCalls: [.init(id: "chatcmpl-1234", function: .init(arguments: "", name: "get_current_weather"))],
-                        reasoning: nil,
-                        reasoningContent: nil
+                        _reasoning: nil,
+                        _reasoningContent: nil
                     ),
                     finishReason: "tool_calls"
                 )


### PR DESCRIPTION
This simplifies the API and hides an unnecessary implementation detail.

<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

This PR unifies the `reasoning` and `reasoning_content` fields into a single public `reasoning` getter.

The internal `reasoning` and `reasoningContent` fields are preserved for en- and decoding purposes, to preserve ABI-compatibility and ensure that re-encoding is lossless.

<!-- Please describe the change -->

## Why

As discussed in https://github.com/MacPaw/OpenAI/pull/311#issuecomment-2775237198.
There is no reason to publicly expose both, as only one or neither of these fields will be set at a time.

## Affected Areas

`ChatResult`, `ChatStreamResult`
