### PR TITLE
Fix role is getting lost in Chat Stream demo

### DIFF
--- a/Demo/DemoChat/Sources/ChatStore.swift
+++ b/Demo/DemoChat/Sources/ChatStore.swift
@@ -251,9 +251,16 @@ public final class ChatStore: ObservableObject {
                 if let existingMessageIndex = existingMessages.firstIndex(where: { $0.id == partialChatResult.id }) {
                     // Meld into previous message
                     let previousMessage = existingMessages[existingMessageIndex]
+                    
+                    let role = if let new = choice.delta.role {
+                        new
+                    } else {
+                        previousMessage.role
+                    }
+                    
                     let combinedMessage = Message(
                         id: message.id, // id stays the same for different deltas
-                        role: message.role,
+                        role: role,
                         content: previousMessage.content + message.content,
                         createdAt: message.createdAt
                     )


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Role is received one in the first message of a stream, so it should be manually forwarded on an SDK client side

## Why

Issue https://github.com/MacPaw/OpenAI/issues/98

## Affected Areas

Demo
