### PR TITLE
327 support none value for chatqueryreasoningeffort

### DIFF
--- a/Tests/OpenAITests/OpenAITestsDecoder.swift
+++ b/Tests/OpenAITests/OpenAITestsDecoder.swift
@@ -320,6 +320,34 @@ class OpenAITestsDecoder: XCTestCase {
         try decode(data, expectedValue)
     }
     
+    func testChatQueryWithReasoningEffort() throws {
+        let chatQuery = ChatQuery(
+            messages: [
+                .init(role: .user, content: "Who are you?")!
+            ],
+            model: .gpt4,
+            reasoningEffort: .low
+        )
+        let expectedValue = """
+            {
+                "model": "gpt-4",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Who are you?"
+                    }
+                ],
+                "reasoning_effort": "low",
+                "stream": 0
+            }
+            """
+        
+        let chatQueryAsDict = try jsonDataAsNSDictionary(JSONEncoder().encode(chatQuery))
+        let expectedValueAsDict = try jsonDataAsNSDictionary(expectedValue.data(using: .utf8)!)
+        
+        XCTAssertEqual(chatQueryAsDict, expectedValueAsDict)
+    }
+    
     func testEmbeddings() async throws {
         let data = """
         {

--- a/Tests/OpenAITests/OpenAITestsDecoder.swift
+++ b/Tests/OpenAITests/OpenAITestsDecoder.swift
@@ -338,7 +338,7 @@ class OpenAITestsDecoder: XCTestCase {
                     }
                 ],
                 "reasoning_effort": "low",
-                "stream": 0
+                "stream": false
             }
             """
         


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Add `.customValue(String)` case to `ChatQuery.ResoningEffort`

## Why

https://github.com/MacPaw/OpenAI/issues/327
Gemini Flash 2.5 has `reasoning-disable` mode that is not supported with OpenAI's schema which only has `low`, `medium` and `high`

## Affected Areas

`ChatQuery.ReasoningEffort`, `OpenAITestsDecoder`
