### PR TITLE
Audio transcription streaming

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -271,6 +271,14 @@ final public class OpenAI: @unchecked Sendable {
         performRequest(request: makeAudioTranscriptionsRequest(query: query), completion: completion)
     }
     
+    public func audioTranscriptionStream(query: AudioTranscriptionQuery, onResult: @escaping @Sendable (Result<AudioTranscriptionStreamResult, Error>) -> Void, completion: (@Sendable (Error?) -> Void)?) -> CancellableRequest {
+        performStreamingRequest(
+            request: makeAudioTranscriptionsRequest(query: query.makeStreamable()),
+            onResult: onResult,
+            completion: completion
+        )
+    }
+    
     public func audioTranslations(query: AudioTranslationQuery, completion: @escaping @Sendable (Result<AudioTranslationResult, Error>) -> Void) -> CancellableRequest {
         performRequest(request: makeAudioTranslationsRequest(query: query), completion: completion)
     }

--- a/Sources/OpenAI/Public/Models/AudioTranscriptionQuery.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranscriptionQuery.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct AudioTranscriptionQuery: Codable {
+public struct AudioTranscriptionQuery: Codable, Streamable, Sendable {
     
     public enum TimestampGranularities: String, Codable, Equatable, CaseIterable {
         case word
@@ -22,10 +22,14 @@ public struct AudioTranscriptionQuery: Codable {
         case vtt
     }
 
+    public enum Include: String, Codable, Equatable, CaseIterable {
+        case logprobs
+    }
+
     /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
     public let file: Data
     public let fileType: Self.FileType
-    /// ID of the model to use. Only whisper-1 is currently available.
+    /// ID of the model to use. whisper-1, gpt-4o-transcribe and gpt-4o-mini-transcribe are currently available.
     public let model: Model
     /// The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt.
     /// Defaults to json
@@ -38,11 +42,14 @@ public struct AudioTranscriptionQuery: Codable {
     /// The language of the input audio. Supplying the input language in ISO-639-1 format will improve accuracy and latency.
     /// https://platform.openai.com/docs/guides/speech-to-text/prompting
     public let language: String?
+    public var stream: Bool
     /// The timestamp granularities to populate for this transcription. response_format must be set verbose_json to use timestamp granularities. Either or both of these options are supported: word, or segment. Note: There is no additional latency for segment timestamps, but generating word timestamps incurs additional latency.
     /// Defaults to segment
     public let timestampGranularities: [Self.TimestampGranularities]
+    /// Additional information to include in the transcription response. logprobs will return the log probabilities of the tokens in the response to understand the model's confidence in the transcription. logprobs only works with response_format set to json and only with the models gpt-4o-transcribe and gpt-4o-mini-transcribe.
+    public let include: [Self.Include]
 
-    public init(file: Data, fileType: Self.FileType, model: Model, prompt: String? = nil, temperature: Double? = nil, language: String? = nil, responseFormat: Self.ResponseFormat? = nil, timestampGranularities: [Self.TimestampGranularities] = []) {
+    public init(file: Data, fileType: Self.FileType, model: Model, prompt: String? = nil, temperature: Double? = nil, language: String? = nil, responseFormat: Self.ResponseFormat? = nil, stream: Bool = false, timestampGranularities: [Self.TimestampGranularities] = [], include: [Self.Include] = []) {
         self.file = file
         self.fileType = fileType
         self.model = model
@@ -50,7 +57,9 @@ public struct AudioTranscriptionQuery: Codable {
         self.temperature = temperature
         self.language = language
         self.responseFormat = responseFormat
+        self.stream = stream
         self.timestampGranularities = timestampGranularities
+        self.include = include
     }
 
     public enum FileType: String, Codable, Equatable, CaseIterable {
@@ -91,14 +100,19 @@ public struct AudioTranscriptionQuery: Codable {
 extension AudioTranscriptionQuery: MultipartFormDataBodyEncodable {
     
     func encode(boundary: String) -> Data {
-        let bodyBuilder = MultipartFormDataBodyBuilder(boundary: boundary, entries: [
+        let bodyBuilder = MultipartFormDataBodyBuilder(
+            boundary: boundary, 
+            entries: [
             .file(paramName: "file", fileName: fileType.fileName, fileData: file, contentType: fileType.contentType),
             .string(paramName: "model", value: model),
             .string(paramName: "prompt", value: prompt),
             .string(paramName: "temperature", value: temperature),
             .string(paramName: "language", value: language),
             .string(paramName: "response_format", value: responseFormat?.rawValue),
-            ] + timestampGranularities.map({.string(paramName: "timestamp_granularities[]", value: $0)})
+            .string(paramName: "stream", value: stream),
+            ]
+            + timestampGranularities.map({.string(paramName: "timestamp_granularities[]", value: $0)})
+            + include.map({.string(paramName: "include[]", value: $0)})
         )
         
         return bodyBuilder.build()

--- a/Sources/OpenAI/Public/Models/AudioTranscriptionStreamResult.swift
+++ b/Sources/OpenAI/Public/Models/AudioTranscriptionStreamResult.swift
@@ -1,0 +1,55 @@
+//
+//  AudioTranscriptionStreamResult.swift
+//  
+//
+//  Created by Simon Liang on 08/05/2025.
+//
+
+import Foundation
+
+public struct AudioTranscriptionStreamResult: Codable, Equatable, Sendable {
+    /// The type of the event.
+    public let type: EventType
+    
+    /// The text delta that was additionally transcribed. Only present for "transcript.text.delta" events.
+    public let delta: String?
+    
+    /// The complete transcription text. Only present for "transcript.text.done" events.
+    public let text: String?
+    
+    /// The log probabilities of the individual tokens in the transcription. Only included if you
+    /// create a transcription with the include[] parameter set to logprobs.
+    public let logprobs: [LogProb]?
+    
+    public enum EventType: String, Codable, Equatable, CaseIterable, Sendable {
+        case delta = "transcript.text.delta"
+        case done = "transcript.text.done"
+    }
+    
+    public struct LogProb: Codable, Equatable, Sendable {
+        /// The token.
+        public let token: String
+        /// A list of integers representing the UTF-8 bytes representation of the token.
+        public let bytes: [Int]?
+        /// The log probability of this token.
+        public let logprob: Double
+    }
+    
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let parsingOptions = decoder.userInfo[.parsingOptions] as? ParsingOptions ?? []
+        
+        let typeString = try container.decodeString(forKey: .type, parsingOptions: parsingOptions)
+        self.type = EventType(rawValue: typeString) ?? .delta
+        self.delta = try container.decodeIfPresent(String.self, forKey: .delta)
+        self.text = try container.decodeIfPresent(String.self, forKey: .text)
+        self.logprobs = try container.decodeIfPresent([LogProb].self, forKey: .logprobs)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case delta
+        case text
+        case logprobs
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

I am trying to add [audio transcription API streaming support](https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-stream).

## Why

I need it in my project and it seems straightforward to add based on what we currently have. This also hopefully solves #296 .

## Affected Areas

Added `AudioTranscriptionStreamResult` and use the same SSE wrapper as `chatStream` to create `audioTranscriptionStream`.

Hopefully this is working since I am new to Swift contributions. I am still learning to add tests, so right now there isn't test coverage for my changes yet. It would be good to get some advice to test the streaming request. Cheers!
