### PR TITLE
feat: image edits for gpt-image-1

### DIFF
--- a/Demo/DemoChat/Sources/UI/Images/ImageEditView.swift
+++ b/Demo/DemoChat/Sources/UI/Images/ImageEditView.swift
@@ -1,0 +1,247 @@
+//
+//  ImageEditView.swift
+//  DemoChat
+//
+//  Created by Jim Wang on 2025/5/9.
+//
+
+import SwiftUI
+import PhotosUI
+import OpenAI
+
+public struct ImageEditView: View {
+    @ObservedObject var store: ImageStore
+
+    @State private var maxPhotos = 2
+    @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    @State private var selectedImages: [UIImage] = []
+
+    @State private var selectedMaskItem: PhotosPickerItem?
+    @State private var maskImage: UIImage?
+
+    @State private var prompt: String = "Generate a photorealistic image of a gift basket on a white background labeled \"Relax & Unwind\" with a ribbon and handwriting-like font, containing all the items in the reference pictures'"
+
+    @State private var resultImage: UIImage?
+    @State private var resultUrl: URL?
+
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+
+    @State private var selectedModel: Model = .gpt_image_1
+    private let models: [Model] = [.gpt_image_1, .dall_e_2]
+
+    public init(store: ImageStore) {
+        self.store = store
+    }
+
+    public var body: some View {
+        List {
+            Section {
+                VStack {
+                    if let resultImage {
+                        Image(uiImage: resultImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: .infinity)
+                            .cornerRadius(12)
+                    } else if let resultUrl, UIApplication.shared.canOpenURL(resultUrl) {
+                        LinkPreview(previewURL: resultUrl)
+                            .aspectRatio(contentMode: .fit)
+                    } else {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.gray.opacity(0.2))
+                            .frame(height: 200)
+                            .overlay(Text("Result will appear here").foregroundColor(.gray))
+                    }
+
+                    if isLoading || errorMessage != nil {
+                        Divider()
+
+                        if isLoading {
+                            HStack {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+                            }
+                        }
+
+                        if let errorMessage {
+                            Text(errorMessage)
+                                .foregroundColor(.red)
+                                .font(.caption)
+                                .padding(.top, 4)
+                        }
+                    }
+                }
+            }
+
+            Section(header: Text("Model")) {
+                Picker("Select Model", selection: $selectedModel) {
+                    ForEach(models, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+
+            Section(header: Text("Prompt")) {
+                TextField("Enter your prompt...", text: $prompt)
+            }
+
+            Section(header: Text("Input Image")) {
+                HStack(spacing: 8) {
+                    PhotosPicker(selection: $selectedPhotoItems, maxSelectionCount: maxPhotos, matching: .images) {
+                        Label("", systemImage: "photo")
+                            .foregroundStyle(Color.black)
+                    }
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        LazyHStack {
+                            ForEach(0..<maxPhotos, id: \.self) { index in
+                                if index < selectedImages.count {
+                                    Image(uiImage: selectedImages[index])
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fill)
+                                        .frame(width: 64, height: 64)
+                                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                                } else {
+                                    placeholderImage()
+                                }
+                            }
+                        }
+                    }
+                    Spacer()
+                }
+                .padding(8)
+                .frame(height: 80)
+                .cornerRadius(16)
+            }
+
+            Section(header: Text("Mask Image")) {
+                HStack(spacing: 8) {
+                    PhotosPicker(selection: $selectedMaskItem, matching: .images) {
+                        Label("", systemImage: "photo")
+                            .foregroundStyle(Color.black)
+                    }
+                    if let maskImage {
+                        Image(uiImage: maskImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 64, height: 64)
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
+                    } else {
+                        placeholderImage()
+                    }
+
+                    Spacer()
+                }
+                .padding(8)
+                .frame(height: 80)
+                .cornerRadius(16)
+            }
+
+            Section {
+                Button("Generate Image") {
+                    Task {
+                        await generateImage()
+                    }
+                }
+                .disabled(prompt.isEmpty || selectedImages.isEmpty || isLoading)
+            }
+        }
+        .onChange(of: selectedModel) { newModel in
+            switch newModel {
+            case .gpt_image_1:
+                selectedPhotoItems = []
+                selectedImages = []
+                maxPhotos = 2
+            default:
+                selectedPhotoItems = []
+                selectedImages = []
+                maxPhotos = 1
+            }
+        }
+        .onChange(of: selectedMaskItem) { newMaskItem in
+            Task {
+                await loadMaskImage(from: newMaskItem)
+            }
+        }
+        .onChange(of: selectedPhotoItems) { newItems in
+            Task {
+                await loadSelectedImages(from: newItems)
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Create Image Edit")
+    }
+
+    private func placeholderImage() -> some View {
+        RoundedRectangle(cornerRadius: 16)
+            .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [5]))
+            .frame(width: 64, height: 64)
+            .overlay(Image(systemName: "photo").foregroundColor(.gray))
+    }
+
+    private func loadSelectedImages(from items: [PhotosPickerItem]) async {
+        var images: [UIImage] = []
+        for item in items.prefix(maxPhotos) {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let image = UIImage(data: data) {
+                images.append(image)
+            }
+        }
+        selectedImages = images
+    }
+
+    private func loadMaskImage(from item: PhotosPickerItem?) async {
+        guard let item,
+                let data = try? await item.loadTransferable(type: Data.self),
+                let mask = UIImage(data: data) else {
+            maskImage = nil
+            return
+        }
+        maskImage = mask
+    }
+
+    @MainActor
+    private func generateImage() async {
+        isLoading = true
+        errorMessage = nil
+        resultImage = nil
+        defer {
+            isLoading = false
+        }
+
+        let inputImages: [ImageEditsQuery.InputImage] = selectedImages
+            .compactMap { $0.pngData() }
+            .map { .png($0) }
+
+        let query = ImageEditsQuery(
+            images: inputImages,
+            prompt: prompt,
+            mask: maskImage?.pngData(),
+            model: selectedModel
+        )
+
+        do {
+            let imageResult = try await store.openAIClient.imageEdits(query: query)
+            guard let image = imageResult.data.first else {
+                errorMessage = "No image"
+                return
+            }
+
+            if let b64JSON = image.b64Json {
+                guard let data = Data(base64Encoded: b64JSON), let result = UIImage(data: data) else {
+                    errorMessage = "Failed to decode image."
+                    return
+                }
+                resultImage = result
+            } else if let url = image.url {
+                resultUrl = URL(string: url)!
+            } else {
+                errorMessage = "No image"
+            }
+        } catch {
+            errorMessage = "Error: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Demo/DemoChat/Sources/UI/Images/ImageView.swift
+++ b/Demo/DemoChat/Sources/UI/Images/ImageView.swift
@@ -19,7 +19,6 @@ public struct ImageView: View {
             List {
                 NavigationLink("Create Image", destination: ImageCreationView(store: store))
                 NavigationLink("Create Image Edit", destination: ImageEditView(store: store))
-                    .disabled(true)
                 NavigationLink("Create Image Variation", destination: ImageVariationView(store: store))
                     .disabled(true)
                 
@@ -27,22 +26,6 @@ public struct ImageView: View {
             .listStyle(.insetGrouped)
             .navigationTitle("Image")
         }
-    }
-}
-
-public struct ImageEditView: View {
-    @ObservedObject var store: ImageStore
-    
-    public init(store: ImageStore) {
-        self.store = store
-    }
-    
-    public var body: some View {
-        List {
-            
-        }
-        .listStyle(.insetGrouped)
-        .navigationTitle("Create Image Edit")
     }
 }
 

--- a/Sources/OpenAI/Public/Models/ImageEditsQuery.swift
+++ b/Sources/OpenAI/Public/Models/ImageEditsQuery.swift
@@ -7,12 +7,18 @@
 
 import Foundation
 
-public struct ImageEditsQuery: Codable {
+public struct ImageEditsQuery {
+
+    public typealias InputImage = ImagesQuery.InputImage
     public typealias ResponseFormat = ImagesQuery.ResponseFormat
     public typealias Size = ImagesQuery.Size
+    public typealias Quality = ImagesQuery.Quality
 
-    /// The image to edit. Must be a valid PNG file, less than 4MB, and square. If mask is not provided, image must have transparency, which will be used as the mask.
-    public let image: Data
+    /// The images to edit. Must be a supported image file or an array of images.
+    /// For gpt-image-1, each image should be a png, webp, or jpg file less than 25MB.
+    /// For dall-e-2, you can only provide one image, and it should be a square png file less than 4MB.
+    public let images: [InputImage]
+
     /// An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where image should be edited. Must be a valid PNG file, less than 4MB, and have the same dimensions as image.
     public let mask: Data?
     /// A text description of the desired image(s). The maximum length is 1000 characters.
@@ -22,42 +28,77 @@ public struct ImageEditsQuery: Codable {
     public let model: Model?
     /// The number of images to generate. Must be between 1 and 10.
     public let n: Int?
+    /// The quality of the image that will be generated.
+    /// high, medium and low are only supported for gpt-image-1.
+    /// dall-e-2, dall-e-3 only supports standard quality. Defaults to auto.
+    public let quality: Quality?
     /// The format in which the generated images are returned. Must be one of url or b64_json.
     /// Defaults to url
     public let responseFormat: Self.ResponseFormat?
-    /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+    /// The size of the generated images. Must be one of 256x256, 512x512, 1024x1024, 1536x
+    /// - For gpt-image-1, one of `1024x1024`, `1536x1024` (landscape), `1024x1536` (portrait), or `auto` (default value)
+    /// - For dall-e-2, one of `256x256`, `512x512`, or `1024x1024`
     public let size: Size?
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     /// https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
     public let user: String?
 
+    @available(*, deprecated, message: "Use init(images:prompt:mask:model:n:quality:responseFormat:size:user:) instead. This initializer is kept for backward compatibility.")
+    // For backward compatibility, the image must be a square PNG file smaller than 4MB.
     public init(
         image: Data,
         prompt: String,
         mask: Data? = nil,
         model: Model? = nil,
         n: Int? = nil,
+        quality: Quality? = nil,
         responseFormat: Self.ResponseFormat? = nil,
         size: Self.Size? = nil,
         user: String? = nil
     ) {
-        self.image = image
+        self.init(
+            images: [.png(image)],
+            prompt: prompt,
+            mask: mask,
+            model: model,
+            n: n,
+            quality: quality,
+            responseFormat: responseFormat,
+            size: size,
+            user: user
+        )
+    }
+
+    public init(
+        images: [InputImage],
+        prompt: String,
+        mask: Data? = nil,
+        model: Model? = nil,
+        n: Int? = nil,
+        quality: Quality? = nil,
+        responseFormat: Self.ResponseFormat? = nil,
+        size: Self.Size? = nil,
+        user: String? = nil
+    ) {
+        self.images = images
         self.mask = mask
         self.prompt = prompt
         self.model = model
         self.n = n
+        self.quality = quality
         self.responseFormat = responseFormat
         self.size = size
         self.user = user
     }
 
     public enum CodingKeys: String, CodingKey {
-        case image
+        case images
         case mask
         case prompt
         case model
         case n
         case responseFormat = "response_format"
+        case quality
         case size
         case user
     }
@@ -65,16 +106,42 @@ public struct ImageEditsQuery: Codable {
 
 extension ImageEditsQuery: MultipartFormDataBodyEncodable {
     func encode(boundary: String) -> Data {
-        let bodyBuilder = MultipartFormDataBodyBuilder(boundary: boundary, entries: [
-            .file(paramName: "image", fileName: "image.png", fileData: image, contentType: "image/png"),
+        var entries: [MultipartFormDataEntry] = [
             .file(paramName: "mask", fileName: "mask.png", fileData: mask, contentType: "image/png"),
             .string(paramName: "model", value: model),
             .string(paramName: "response_format", value: responseFormat),
             .string(paramName: "user", value: user),
             .string(paramName: "prompt", value: prompt),
             .string(paramName: "n", value: n),
-            .string(paramName: "size", value: size)
-        ])
+            .string(paramName: "size", value: size),
+            .string(paramName: "quality", value: quality?.rawValue)
+        ]
+
+        // Only gpt-image-1 supports multiple images, so fallback to single image upload for others
+        if images.count > 1 {
+            for (index, image) in images.enumerated() {
+                entries.append(
+                    .file(
+                        paramName: "image[]",
+                        fileName: "tmpfile\(index)",
+                        fileData: image.content,
+                        contentType: image.contentType
+                    )
+                )
+            }
+        } else if images.count == 1 {
+            let image = images[0].content
+            entries.append(
+                .file(
+                    paramName: "image",
+                    fileName: "image.png",
+                    fileData: image,
+                    contentType: "image/png"
+                )
+            )
+        }
+
+        let bodyBuilder = MultipartFormDataBodyBuilder(boundary: boundary, entries: entries)
         return bodyBuilder.build()
     }
 }

--- a/Sources/OpenAI/Public/Models/ImagesQuery.swift
+++ b/Sources/OpenAI/Public/Models/ImagesQuery.swift
@@ -79,13 +79,40 @@ public enum ResponseFormat: String, Codable, Equatable {
     public enum Quality: String, Codable, CaseIterable {
         case standard
         case hd
+        case high, medium, low  /// for gpt-image-1
     }
 
+    /// The size of the generated images.
+    /// - For gpt-image-1, one of `1024x1024`, `1536x1024` (landscape), `1024x1536` (portrait), or `auto` (default value)
     public enum Size: String, Codable, CaseIterable {
         case _256 = "256x256"
         case _512 = "512x512"
         case _1024 = "1024x1024"
         case _1792_1024 = "1792x1024" // for dall-e-3 models
         case _1024_1792 = "1024x1792" // for dall-e-3 models
+        case _1536x1024 = "1536x1024" // only for gpt-image-1
+        case _1024x1536 = "1024x1536" // only for gpt-image-1
+        case auto                     // only for gpt-image-1
+    }
+
+    public enum InputImage {
+        case png(Data)
+        case jpeg(Data)
+
+        public var content: Data {
+            switch self {
+            case let .png(data), let .jpeg(data):
+                return data
+            }
+        }
+
+        public var contentType: String {
+            switch self {
+            case .png:
+                return "image/png"
+            case .jpeg:
+                return "image/jpeg"
+            }
+        }
     }
 }

--- a/Sources/OpenAI/Public/Models/Models/Models.swift
+++ b/Sources/OpenAI/Public/Models/Models/Models.swift
@@ -135,7 +135,8 @@ public extension Model {
     // Image Generation
     static let dall_e_2 = "dall-e-2"
     static let dall_e_3 = "dall-e-3"
-    
+    static let gpt_image_1 = "gpt-image-1"
+
     // Fine Tunes
     
     /// Most capable GPT-3 model. Can do any task the other models can do, often with higher quality.


### PR DESCRIPTION
 ## What

  - Added support for the new `gpt-image-1` model in the ImagesQuery API
     - https://platform.openai.com/docs/guides/image-generation#edit-images
  - Implemented a functional `ImageEditView` for image editing capabilities
  - Enhanced ImageEditsQuery to support multiple input images for `gpt-image-1` model
  - Added new size and quality options specific to `gpt-image-1` model

## Why

  - The new gpt-image-1 model from OpenAI provides improved image editing capabilities, including the ability to use multiple reference images
  - This implementation allows users to create image edits using both DALL-E 2 and the newer gpt-image-1 model

## Affected Areas

  - Image editing API (ImageEditsQuery)
  - Model definitions (added gpt-image-1)
  - Demo application UI (implemented ImageEditView)
  
## Demo

<table>
<tr>
<th>gpt-image-1 multiple images</th>
<th>gpt-image-1</th>
<th>dall-e-2</th>
</tr>
<tr>
<td>


https://github.com/user-attachments/assets/2f7d2b70-818b-4399-8cdf-3705618e0482


</td>
<td>

<img src="https://github.com/user-attachments/assets/2639cc5a-d5f6-427b-a70c-a5c1ff166fba" width=300/>

</td>
<td>

https://github.com/user-attachments/assets/049e0b3c-0ef4-47b1-bf6d-25d288ca5079


</td>
</tr>
</table>