### PR TITLE
Fix SSE parser

### DIFF
--- a/Sources/OpenAI/Private/Streaming/ServerSentEventsStreamParser.swift
+++ b/Sources/OpenAI/Private/Streaming/ServerSentEventsStreamParser.swift
@@ -108,7 +108,7 @@ final class ServerSentEventsStreamParser: @unchecked Sendable {
             previousCharacter = currentChar
         }
         
-        if lineBeginningIndex < streamData.count - 1 {
+        if lineBeginningIndex < streamData.count {
             return (lines, streamData.subdata(in: lineBeginningIndex..<streamData.count))
         } else {
             return (lines, nil)


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Fix SSE parser to handle single byte in "incomplete"

## Why

[<!-- Please describe the motivation -->](https://github.com/MacPaw/OpenAI/issues/335)

## Affected Areas

ServerSentEventsStreamParser and corresponding tests 
