### PR TITLE
Make SSLDelegateProtocol completionHandler parameter Sendable

### DIFF
--- a/Sources/OpenAI/Private/SSLDelegateProtocol.swift
+++ b/Sources/OpenAI/Private/SSLDelegateProtocol.swift
@@ -7,6 +7,6 @@ public protocol SSLDelegateProtocol: Sendable {
     func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     )
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What
Make `SSLDelegateProtocol` completionHandler parameter Sendable

## Why
In Swift 6, a warning appears if the `completionHandler` closure is passed across concurrency domains without being marked @Sendable.
It's the same in `URLSessionDelegate`:
<img width="1471" alt="Screenshot 2025-06-06 at 12 57 56" src="https://github.com/user-attachments/assets/cdad3f6b-3303-43f2-bde7-6b3768ce7c72" />


