### PR TITLE
Extract response handling

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -116,7 +116,10 @@ final public class OpenAI: OpenAIProtocol, @unchecked Sendable {
     ) {
         self.configuration = configuration
         
-        let dataTaskFactory = DataTaskFactory(configuration: configuration, session: session, middlewares: middlewares)
+        let dataTaskFactory = DataTaskFactory(
+            session: session,
+            responseHandler: .init(middlewares: middlewares, configuration: configuration)
+        )
         
         self.client = .init(
             configuration: configuration,
@@ -138,10 +141,16 @@ final public class OpenAI: OpenAIProtocol, @unchecked Sendable {
             configuration: configuration,
             middlewares: middlewares,
             session: session,
-            dataTaskFactory: dataTaskFactory
+            dataTaskFactory: dataTaskFactory,
+            responseHandler: .init(middlewares: middlewares, configuration: configuration)
         )
         
-        self.combineClient = .init(configuration: configuration, session: session, middlewares: middlewares)
+        self.combineClient = .init(
+            configuration: configuration,
+            session: session,
+            middlewares: middlewares,
+            responseHandler: .init(middlewares: middlewares, configuration: configuration)
+        )
         
         self.responses = ResponsesEndpoint(
             client: client,

--- a/Sources/OpenAI/Private/JSONResponseDecoder.swift
+++ b/Sources/OpenAI/Private/JSONResponseDecoder.swift
@@ -1,0 +1,29 @@
+//
+//  File.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 09.06.2025.
+//
+
+import Foundation
+
+struct JSONResponseDecoder {
+    let parsingOptions: ParsingOptions
+    
+    func decodeResponseData<ResultType: Codable>(_ data: Data) throws -> ResultType {
+        let responseDecoder = JSONDecoder()
+        responseDecoder.userInfo[.parsingOptions] = parsingOptions
+        
+        do {
+            return try responseDecoder.decode(ResultType.self, from: data)
+        } catch {
+            let errorDecoder = JSONResponseErrorDecoder(decoder: JSONDecoder())
+            
+            if let decodedError = errorDecoder.decodeErrorResponse(data: data) {
+                throw decodedError
+            } else {
+                throw error
+            }
+        }
+    }
+}

--- a/Sources/OpenAI/Private/Streaming/ServerSentEventsStreamInterpreter.swift
+++ b/Sources/OpenAI/Private/Streaming/ServerSentEventsStreamInterpreter.swift
@@ -66,18 +66,13 @@ final class ServerSentEventsStreamInterpreter <ResultType: Codable & Sendable>: 
                 onError?(StreamingError.unknownContent)
                 return
             }
-            let decoder = JSONDecoder()
-            decoder.userInfo[.parsingOptions] = parsingOptions
+            
+            let decoder = JSONResponseDecoder(parsingOptions: parsingOptions)
             do {
-                let object = try decoder.decode(ResultType.self, from: jsonData)
+                let object: ResultType = try decoder.decodeResponseData(jsonData)
                 onEventDispatched?(object)
             } catch {
-                if let decoded = JSONResponseErrorDecoder(decoder: decoder).decodeErrorResponse(data: jsonData) {
-                    onError?(decoded)
-                    return
-                } else {
-                    onError?(error)
-                }
+                onError?(error)
             }
         default:
             onError?(InterpeterError.unhandledStreamEventType(event.eventType))

--- a/Sources/OpenAI/Private/URLResponseHandler.swift
+++ b/Sources/OpenAI/Private/URLResponseHandler.swift
@@ -1,0 +1,68 @@
+//
+//  URLResponseHandler.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 09.06.2025.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct URLResponseHandler {
+    let middlewares: [OpenAIMiddleware]
+    let configuration: OpenAI.Configuration
+    
+    init(middlewares: [OpenAIMiddleware], configuration: OpenAI.Configuration) {
+        self.middlewares = middlewares
+        self.configuration = configuration
+    }
+    
+    func interceptAndDecode<ResultType: Codable>(response: URLResponse, urlRequest: URLRequest, responseData data: Data) throws -> ResultType {
+        let interceptedData = intercept(response: response, data: data, request: urlRequest)
+        return try decodeJson(data: interceptedData ?? data)
+    }
+    
+    func interceptAndDecode<ResultType: Codable>(response: URLResponse?, urlRequest: URLRequest, error: Error?, responseData data: Data?) throws -> ResultType {
+        let interceptedData = intercept(response: response, data: data, request: urlRequest)
+        let unwrappedData = try self.unwrap(error: error, originalData: data, interceptedData: interceptedData)
+        return try decodeJson(data: unwrappedData)
+    }
+    
+    func interceptAndDecodeRaw(response: URLResponse, urlRequest: URLRequest, responseData data: Data) throws -> Data {
+        let interceptedData = intercept(response: response, data: data, request: urlRequest)
+        return interceptedData ?? data
+    }
+    
+    func interceptAndDecodeRaw(response: URLResponse?, urlRequest: URLRequest, error: Error?, responseData data: Data?) throws -> Data {
+        let interceptedData = intercept(response: response, data: data, request: urlRequest)
+        return try unwrap(error: error, originalData: data, interceptedData: interceptedData)
+    }
+    
+    private func decodeJson<ResultType: Codable>(data: Data) throws -> ResultType {
+        let jsonDecoder = JSONResponseDecoder(parsingOptions: configuration.parsingOptions)
+        return try jsonDecoder.decodeResponseData(data)
+    }
+    
+    private func intercept(response: URLResponse?, data: Data?, request: URLRequest) -> Data? {
+        let (_, interceptedData) = self.middlewares.reduce((response, data)) { current, middleware in
+            middleware.intercept(response: current.response, request: request, data: current.data)
+        }
+        
+        return interceptedData
+    }
+    
+    private func unwrap(error: Error?, originalData: Data?, interceptedData: Data?) throws -> Data {
+        if let error {
+            throw error
+        }
+        
+        let finalData = interceptedData ?? originalData
+        guard let finalData else {
+            throw OpenAIError.emptyData
+        }
+        
+        return finalData
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

We have the same logic for response handling, regardless of whether it's Client, AsyncClient and CombineClient. Extract it to reduce duplication

## Why

We've already got an issue because a change was introduced for one client but not for another. https://github.com/MacPaw/OpenAI/issues/345. The change could prevent such issues in the future

## Affected Areas

Clients, Interpreters
