### PR TITLE
Support OpenRouter models endpoint

### DIFF
--- a/Sources/OpenAI/Public/Models/Models/ModelResult.swift
+++ b/Sources/OpenAI/Public/Models/Models/ModelResult.swift
@@ -38,7 +38,7 @@ public struct ModelResult: Codable, Equatable, Sendable {
         let parsingOptions = decoder.userInfo[.parsingOptions] as? ParsingOptions ?? []
         self.id = try container.decode(String.self, forKey: .id)
         self.created = try container.decodeTimeInterval(forKey: .created, parsingOptions: parsingOptions)
-        self.object = try container.decode(String.self, forKey: .object)
-        self.ownedBy = try container.decode(String.self, forKey: .ownedBy)
+        self.object = try container.decode(String.self, forKey: .object, parsingOptions: parsingOptions, defaultValue: "model")
+        self.ownedBy = try container.decode(String.self, forKey: .ownedBy, parsingOptions: parsingOptions, defaultValue: "")
     }
 }

--- a/Sources/OpenAI/Public/Models/Models/ModelsResult.swift
+++ b/Sources/OpenAI/Public/Models/Models/ModelsResult.swift
@@ -14,4 +14,16 @@ public struct ModelsResult: Codable, Equatable, Sendable {
     public let data: [ModelResult]
     /// The object type, which is always `list`
     public let object: String
+
+    public init(data: [ModelResult], object: String) {
+        self.data = data
+        self.object = object
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let parsingOptions = decoder.userInfo[.parsingOptions] as? ParsingOptions ?? []
+        self.data = try container.decode([ModelResult].self, forKey: .data)
+        self.object = try container.decode(String.self, forKey: .object, parsingOptions: parsingOptions, defaultValue: "list")
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

This PR makes the `/models` endpoint work with OpenRouter.

## Why

Unlike OpenAI, OpenRouter doesn't use the `object` and `owned_by` fields.

I've chosen to use reasonable defaults for `object` (i.e. `list` in `ModelsResult` and `model` in `ModelResult`), and an empty string for `owned_by`, since I don't think there's a better default for that one.

The `ModelsResult` and `ModelResult` structs themselves aren't changed, and this PR makes use of the existing `parsingOptions` mechanism to supply the default values.

## Affected Areas

- Decoding of `ModelsResult` and `ModelResult`, if relaxed parsing options are specified
- No breaking changes
