### PR TITLE
chore: Rewrite ModelResponseEventsStreamInterpreterTests

### DIFF
--- a/Tests/OpenAITests/ChatQueryCodingTests.swift
+++ b/Tests/OpenAITests/ChatQueryCodingTests.swift
@@ -1,5 +1,5 @@
 //
-//  Test.swift
+//  ChatQueryCodingTests.swift
 //  OpenAI
 //
 //  Created by Oleksii Nezhyborets on 20.05.2025.

--- a/Tests/OpenAITests/ModelResponseEventsStreamInterpreterTests.swift
+++ b/Tests/OpenAITests/ModelResponseEventsStreamInterpreterTests.swift
@@ -1,37 +1,42 @@
 //
-//  Test.swift
-//  OpenAI
+//  ModelResponseEventsStreamInterpreterTests.swift
+//  OpenAI
 //
-//  Created by Oleksii Nezhyborets on 10.04.2025.
+//  Created by Oleksii Nezhyborets on 10.04.2025.
 //
 
-import Testing
+import XCTest
 @testable import OpenAI
 
 @MainActor
-struct Test {
+final class ModelResponseEventsStreamInterpreterTests: XCTestCase {
     private let interpreter = ModelResponseEventsStreamInterpreter()
-    
-    @Test(.timeLimit(.minutes(1)))
-    func parseApiError() async throws {
-        var error: Error!
-        
-        await withCheckedContinuation { continuation in
-            interpreter.setCallbackClosures { result in
-            } onError: { apiError in
-                Task {
-                    await MainActor.run {
-                        error = apiError
-                        continuation.resume()
-                    }
+
+    func testParseApiError() async throws {
+        let expectation = XCTestExpectation(description: "API Error callback received")
+        var receivedError: Error?
+
+        interpreter.setCallbackClosures { result in
+            // This closure is for successful results, which we don't expect here
+            XCTFail("Unexpected successful result received")
+        } onError: { apiError in
+            Task {
+                await MainActor.run {
+                    receivedError = apiError
+                    expectation.fulfill() // Fulfill the expectation when the error is received
                 }
             }
-            
-            interpreter.processData(
-                MockServerSentEvent.chatCompletionError()
-            )
         }
-        
-        #expect(error is APIErrorResponse)
+
+        interpreter.processData(
+            MockServerSentEvent.chatCompletionError()
+        )
+
+        // Wait for the expectation to be fulfilled, with a timeout
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        // Assert that an error was received and that it is of the expected type
+        XCTAssertNotNil(receivedError, "Expected an error to be received, but got nil.")
+        XCTAssertTrue(receivedError is APIErrorResponse, "Expected received error to be of type APIErrorResponse.")
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Rewrite ModelResponseEventsStreamInterpreterTests XCTestCase, because .timeLimit Swift Testing traint is not supported on < iOS 16

## Why

A user of the package complained that he has to manually bump versions to run tests

## Affected Areas

ModelResponseEventsStreamInterpreterTests.swift
