### PR TITLE
Fix and test request interception

### DIFF
--- a/Sources/OpenAI/OpenAI+OpenAIAsync.swift
+++ b/Sources/OpenAI/OpenAI+OpenAIAsync.swift
@@ -187,7 +187,7 @@ extension OpenAI: OpenAIAsync {
     }
     
     func performSpeechRequestAsync(request: any URLRequestBuildable) async throws -> AudioSpeechResult {
-        try await asyncClient.performSpeechRequestAsync(request: request)
+        try await asyncClient.performSpeechRequest(request: request)
     }
     
     func makeAsyncStream<ResultType: Codable & Sendable>(

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -131,16 +131,16 @@ final public class OpenAI: OpenAIProtocol, @unchecked Sendable {
         
         self.streamingClient = .init(
             configuration: configuration,
-            middlewares: middlewares,
             streamingSessionFactory: streamingSessionFactory,
+            middlewares: middlewares,
             cancellablesFactory: cancellablesFactory,
             executionSerializer: executionSerializer
         )
         
         self.asyncClient = .init(
             configuration: configuration,
-            middlewares: middlewares,
             session: session,
+            middlewares: middlewares,
             dataTaskFactory: dataTaskFactory,
             responseHandler: .init(middlewares: middlewares, configuration: configuration)
         )

--- a/Sources/OpenAI/Private/Client/AsyncClient.swift
+++ b/Sources/OpenAI/Private/Client/AsyncClient.swift
@@ -19,14 +19,14 @@ actor AsyncClient {
     
     init(
         configuration: OpenAI.Configuration,
-        middlewares: [OpenAIMiddleware],
         session: URLSessionProtocol,
+        middlewares: [OpenAIMiddleware],
         dataTaskFactory: DataTaskFactory,
         responseHandler: URLResponseHandler
     ) {
         self.configuration = configuration
-        self.middlewares = middlewares
         self.session = session
+        self.middlewares = middlewares
         self.dataTaskFactory = dataTaskFactory
         self.responseHandler = responseHandler
     }
@@ -62,7 +62,7 @@ actor AsyncClient {
         }
     }
     
-    func performSpeechRequestAsync(request: any URLRequestBuildable) async throws -> AudioSpeechResult {
+    func performSpeechRequest(request: any URLRequestBuildable) async throws -> AudioSpeechResult {
         let urlRequest = try request.build(configuration: configuration)
         let interceptedRequest = middlewares.reduce(urlRequest) { current, middleware in
             middleware.intercept(request: current)

--- a/Sources/OpenAI/Private/Client/Client.swift
+++ b/Sources/OpenAI/Private/Client/Client.swift
@@ -50,7 +50,7 @@ final class Client: Sendable {
                 middleware.intercept(request: current)
             }
 
-            let task = dataTaskFactory.makeRawResponseDataTask(forRequest: urlRequest) { result in
+            let task = dataTaskFactory.makeRawResponseDataTask(forRequest: interceptedRequest) { result in
                 switch result {
                 case .success(let success):
                     completion(.success(.init(audio: success)))

--- a/Sources/OpenAI/Private/Client/StreamingClient.swift
+++ b/Sources/OpenAI/Private/Client/StreamingClient.swift
@@ -17,14 +17,14 @@ final class StreamingClient: @unchecked Sendable {
     
     init(
         configuration: OpenAI.Configuration,
-        middlewares: [OpenAIMiddleware],
         streamingSessionFactory: StreamingSessionFactory,
+        middlewares: [OpenAIMiddleware],
         cancellablesFactory: CancellablesFactory,
         executionSerializer: ExecutionSerializer
     ) {
         self.configuration = configuration
-        self.middlewares = middlewares
         self.streamingSessionFactory = streamingSessionFactory
+        self.middlewares = middlewares
         self.cancellablesFactory = cancellablesFactory
         self.executionSerializer = executionSerializer
     }

--- a/Tests/OpenAITests/AsyncClientTests.swift
+++ b/Tests/OpenAITests/AsyncClientTests.swift
@@ -1,0 +1,45 @@
+//
+//  Test.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 27.06.2025.
+//
+
+import Testing
+import Foundation
+@testable import OpenAI
+
+struct AsyncClientTests {
+    
+    private let configuration = OpenAI.Configuration(token: "")
+    private let mockSession = URLSessionMock()
+    private let mockMiddleware = MockMiddleware()
+    private let client: AsyncClient
+    
+    private let originalURL = URL(string: "original")!
+    private let interceptedURL = URL(string: "intercepted")!
+    
+    init() {
+        self.client = AsyncClient(
+            configuration: configuration,
+            session: mockSession,
+            middlewares: [mockMiddleware],
+            dataTaskFactory: DataTaskFactory(session: mockSession, responseHandler: .init(middlewares: [mockMiddleware], configuration: configuration)),
+            responseHandler: .init(middlewares: [mockMiddleware], configuration: configuration)
+        )
+    }
+
+    @Test func interceptRequest() async throws {
+        mockSession.dataTask = try DataTaskMock.successfulJson(with: ChatResult.mock)
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        let _: ChatResult = try await client.performRequest(request: JSONRequest<ChatResult>(url: originalURL))
+        #expect(mockSession.dataAsyncCalls[0].request.url == interceptedURL)
+    }
+    
+    @Test func interceptSpeechRequest() async throws {
+        mockSession.dataTask = try DataTaskMock.successfulJson(with: AudioSpeechResult(audio: .init()))
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        let _: AudioSpeechResult = try await client.performSpeechRequest(request: JSONRequest<AudioSpeechResult>(url: originalURL))
+        #expect(mockSession.dataAsyncCalls[0].request.url == interceptedURL)
+    }
+}

--- a/Tests/OpenAITests/ClientTests.swift
+++ b/Tests/OpenAITests/ClientTests.swift
@@ -1,0 +1,45 @@
+//
+//  Test.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 27.06.2025.
+//
+
+import Testing
+import Foundation
+@testable import OpenAI
+
+struct ClientTests {
+    
+    private let configuration = OpenAI.Configuration(token: "")
+    private let mockSession = URLSessionMock()
+    private let mockMiddleware = MockMiddleware()
+    private let client: Client
+    
+    private let originalURL = URL(string: "original")!
+    private let interceptedURL = URL(string: "intercepted")!
+    
+    init() {
+        self.client = Client(
+            configuration: configuration,
+            session: mockSession,
+            middlewares: [mockMiddleware],
+            dataTaskFactory: DataTaskFactory(session: mockSession, responseHandler: .init(middlewares: [mockMiddleware], configuration: configuration)),
+            cancellablesFactory: MockCancellablesFactory()
+        )
+        
+        mockSession.dataTask = DataTaskMock()
+    }
+
+    @Test func interceptRequest() async throws {
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        _ = client.performRequest(request: JSONRequest<ChatResult>(url: originalURL), completion: { (result: Result<ChatResult, Error>) in })
+        #expect(mockSession.dataTaskWithCompletionCalls[0].request.url == interceptedURL)
+    }
+    
+    @Test func interceptSpeechRequest() async throws {
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        _ = client.performSpeechRequest(request: JSONRequest<AudioSpeechResult>(url: originalURL), completion: { (result: Result<AudioSpeechResult, Error>) in })
+        #expect(mockSession.dataTaskWithCompletionCalls[0].request.url == interceptedURL)
+    }
+}

--- a/Tests/OpenAITests/CombineClientTests.swift
+++ b/Tests/OpenAITests/CombineClientTests.swift
@@ -1,0 +1,47 @@
+//
+//  CombineClientTests.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 27.06.2025.
+//
+
+#if canImport(Combine)
+import Testing
+import Foundation
+@testable import OpenAI
+import Combine
+
+struct CombineClientTests {
+    
+    private let configuration = OpenAI.Configuration(token: "")
+    private let mockSession = URLSessionMock()
+    private let mockMiddleware = MockMiddleware()
+    private let client: CombineClient
+    
+    private let originalURL = URL(string: "original")!
+    private let interceptedURL = URL(string: "intercepted")!
+    
+    init() {
+        self.client = CombineClient(
+            configuration: configuration,
+            session: mockSession,
+            middlewares: [mockMiddleware],
+            responseHandler: .init(middlewares: [mockMiddleware], configuration: configuration)
+        )
+    }
+
+    @Test func interceptRequest() async throws {
+        mockSession.dataTask = try DataTaskMock.successfulJson(with: ChatResult.mock)
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        let _: AnyPublisher<ChatResult, Error> = client.performRequest(request: JSONRequest<ChatResult>(url: originalURL))
+        #expect(mockSession.dataTaskPublisherCalls[0].request.url == interceptedURL)
+    }
+    
+    @Test func interceptSpeechRequest() async throws {
+        mockSession.dataTask = try DataTaskMock.successfulJson(with: AudioSpeechResult(audio: .init()))
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        let _: AnyPublisher<AudioSpeechResult, Error> = client.performSpeechRequest(request: JSONRequest<AudioSpeechResult>(url: originalURL))
+        #expect(mockSession.dataTaskPublisherCalls[0].request.url == interceptedURL)
+    }
+}
+#endif

--- a/Tests/OpenAITests/Mocks/DataTaskMock.swift
+++ b/Tests/OpenAITests/Mocks/DataTaskMock.swift
@@ -32,6 +32,15 @@ class DataTaskMock: URLSessionDataTaskProtocol, @unchecked Sendable {
 }
 
 extension DataTaskMock {
+    static func successfulJson(with codable: Codable) throws -> DataTaskMock {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(codable)
+        
+        let task = DataTaskMock()
+        task.data = data
+        task.response = HTTPURLResponse(url: URL(fileURLWithPath: ""), statusCode: 200, httpVersion: nil, headerFields: nil)
+        return task
+    }
     
     static func successful(with data: Data) -> DataTaskMock {
         let task = DataTaskMock()

--- a/Tests/OpenAITests/Mocks/MockCancellablesFactory.swift
+++ b/Tests/OpenAITests/Mocks/MockCancellablesFactory.swift
@@ -9,7 +9,7 @@ import Foundation
 @testable import OpenAI
 
 class MockCancellablesFactory: CancellablesFactory, @unchecked Sendable {
-    var taskCanceller: MockTaskCanceller!
+    var taskCanceller = MockTaskCanceller()
     
     func makeTaskCanceller(task: any URLSessionTaskProtocol) -> any CancellableRequest {
         taskCanceller

--- a/Tests/OpenAITests/Mocks/MockMiddleware.swift
+++ b/Tests/OpenAITests/Mocks/MockMiddleware.swift
@@ -1,0 +1,30 @@
+//
+//  MockMiddleware.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 27.06.2025.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import OpenAI
+
+final class MockMiddleware: OpenAIMiddleware, @unchecked Sendable {
+    var interceptRequestReturnValue: URLRequest?
+    var interceptStreamingDataReturnValue: Data?
+    var interceptResponseReturnValue: (response: URLResponse?, data: Data?)?
+    
+    func intercept(request: URLRequest) -> URLRequest {
+        interceptRequestReturnValue ?? request
+    }
+    
+    func interceptStreamingData(request: URLRequest?, _ data: Data) -> Data {
+        interceptStreamingDataReturnValue ?? data
+    }
+    
+    func intercept(response: URLResponse?, request: URLRequest, data: Data?) -> (response: URLResponse?, data: Data?) {
+        interceptResponseReturnValue ?? (response, data)
+    }
+}

--- a/Tests/OpenAITests/Mocks/MockStreamingSessionFactory.swift
+++ b/Tests/OpenAITests/Mocks/MockStreamingSessionFactory.swift
@@ -61,10 +61,12 @@ class MockStreamingSessionFactory: StreamingSessionFactory, @unchecked Sendable 
         onComplete: @Sendable @escaping (StreamingSession<ModelResponseEventsStreamInterpreter>, (any Error)?) -> Void
     ) -> StreamingSession<ModelResponseEventsStreamInterpreter> {
         .init(
+            urlSessionFactory: urlSessionFactory,
             urlRequest: urlRequest,
             interpreter: .init(),
             sslDelegate: nil,
             middlewares: [],
+            executionSerializer: executionSerializer,
             onReceiveContent: onReceiveContent,
             onProcessingError: onProcessingError,
             onComplete: onComplete
@@ -72,8 +74,4 @@ class MockStreamingSessionFactory: StreamingSessionFactory, @unchecked Sendable 
     }
 }
 
-struct NoDispatchExecutionSerializer: ExecutionSerializer {
-    func dispatch(_ closure: @escaping () -> Void) {
-        closure()
-    }
-}
+

--- a/Tests/OpenAITests/Mocks/NoDispatchExecutionSerializer.swift
+++ b/Tests/OpenAITests/Mocks/NoDispatchExecutionSerializer.swift
@@ -1,0 +1,15 @@
+//
+//  NoDispatchExecutionSerializer.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 28.06.2025.
+//
+
+import Foundation
+@testable import OpenAI
+
+struct NoDispatchExecutionSerializer: ExecutionSerializer {
+    func dispatch(_ closure: @escaping () -> Void) {
+        closure()
+    }
+}

--- a/Tests/OpenAITests/Mocks/URLSessionMock.swift
+++ b/Tests/OpenAITests/Mocks/URLSessionMock.swift
@@ -12,24 +12,47 @@ import FoundationNetworking
 @testable import OpenAI
 
 class URLSessionMock: URLSessionProtocol, @unchecked Sendable {
+    struct DataTaskCallParams {
+        let request: URLRequest
+    }
+    
+    struct DataTaskWithCompletionCallParams {
+        let request: URLRequest
+        let completionHandler: @Sendable (Data?, URLResponse?, Error?) -> Void
+    }
+    
+    struct DataAsyncCallParams {
+        let request: URLRequest
+        let delegate: (any URLSessionTaskDelegate)?
+    }
+    
     var dataTask: DataTaskMock!
     var dataTaskIsCancelled = false
     
     var delegate: URLSessionDataDelegateProtocol?
+    
+    var dataTaskCalls: [DataTaskCallParams] = []
+    var dataTaskWithCompletionCalls: [DataTaskWithCompletionCallParams] = []
+    var dataAsyncCalls: [DataAsyncCallParams] = []
+    var dataTaskPublisherCalls: [DataTaskCallParams] = []
     
     var invalidateAndCancelCallCount = 0
     var finishTasksAndInvalidateCallCount = 0
     
     func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
         dataTask.completion = completionHandler
+        dataTaskWithCompletionCalls.append(.init(request: request, completionHandler: completionHandler))
         return dataTask
     }
     
     func dataTask(with request: URLRequest) -> URLSessionDataTaskProtocol {
-        dataTask
+        dataTaskCalls.append(.init(request: request))
+        return dataTask
     }
     
     func data(for request: URLRequest, delegate: (any URLSessionTaskDelegate)?) async throws -> (Data, URLResponse) {
+        dataAsyncCalls.append(.init(request: request, delegate: delegate))
+        
         let result = try await withCheckedThrowingContinuation { continuation in
             if let data = dataTask.data {
                 continuation.resume(returning: (data, dataTask.response!))
@@ -51,6 +74,8 @@ class URLSessionMock: URLSessionProtocol, @unchecked Sendable {
     
 #if canImport(Combine)
     func dataTaskPublisher(for request: URLRequest) -> AnyPublisher<(data: Data, response: URLResponse), URLError> {
+        dataTaskPublisherCalls.append(.init(request: request))
+        
         if let data = dataTask.data {
             return Just((data, dataTask.response!))
                 .setFailureType(to: URLError.self)

--- a/Tests/OpenAITests/StreamingClientTests.swift
+++ b/Tests/OpenAITests/StreamingClientTests.swift
@@ -1,0 +1,70 @@
+//
+//  StreamingClientTests.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 27.06.2025.
+//
+
+import Testing
+import Foundation
+@testable import OpenAI
+
+struct StreamingClientTests {
+    
+    private let configuration = OpenAI.Configuration(token: "")
+    private let mockSessionFactory = MockStreamingSessionFactory()
+    private let mockMiddleware = MockMiddleware()
+    private let client: StreamingClient
+    
+    private let originalURL = URL(string: "original")!
+    private let interceptedURL = URL(string: "intercepted")!
+    
+    private var mockSession: URLSessionMock {
+        mockSessionFactory.urlSessionFactory.urlSession
+    }
+    
+    init() {
+        self.client = StreamingClient(
+            configuration: configuration,
+            streamingSessionFactory: mockSessionFactory,
+            middlewares: [mockMiddleware],
+            cancellablesFactory: MockCancellablesFactory(),
+            executionSerializer: NoDispatchExecutionSerializer()
+        )
+    }
+
+    @Test func interceptRequest() async throws {
+        mockSession.dataTask = try DataTaskMock.successfulJson(with: ChatResult.mock)
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        _ = client.performStreamingRequest(
+            request: JSONRequest<ChatResult>(url: originalURL),
+            onResult: { (result: Result<ChatResult, Error>) in },
+            completion: { _ in }
+        )
+        #expect(mockSession.dataTaskCalls[0].request.url == interceptedURL)
+    }
+    
+    @Test func interceptSpeechRequest() async throws {
+        mockSession.dataTask = try DataTaskMock.successfulJson(with: AudioSpeechResult(audio: .init()))
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        _ = client.performSpeechStreamingRequest(
+            request: JSONRequest<AudioSpeechResult>(url: originalURL),
+            onResult: { (result: Result<AudioSpeechResult, Error>) in },
+            completion: { _ in }
+        )
+        
+        #expect(mockSession.dataTaskCalls[0].request.url == interceptedURL)
+    }
+    
+    @Test func interceptResponsesRequest() async throws {
+        mockSession.dataTask = try DataTaskMock.successfulJson(with: ResponseStreamEvent.audio(.done(.init(_type: .response_audio_done, sequenceNumber: 0))))
+        mockMiddleware.interceptRequestReturnValue = .init(url: interceptedURL)
+        _ = client.performResponsesStreamingRequest(
+            request: JSONRequest<ResponseStreamEvent>(url: originalURL),
+            onResult: { (result: Result<ResponseStreamEvent, Error>) in },
+            completion: { _ in }
+        )
+        
+        #expect(mockSession.dataTaskCalls[0].request.url == interceptedURL)
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Fix a place where a request wouldn't be intercepted, thus not applying middleware logic. Test all places where interception happens.

## Why

Have come across the issue and decided not to postpone the work on it

## Affected Areas

Internal clients, tests
