### PR TITLE
chore: Put Sendable to URLSessionDataDelegateProtocol

### DIFF
--- a/Sources/OpenAI/Private/Streaming/StreamingSession.swift
+++ b/Sources/OpenAI/Private/Streaming/StreamingSession.swift
@@ -73,7 +73,7 @@ final class StreamingSession<Interpreter: StreamInterpreter>: NSObject, Identifi
         _ session: URLSessionProtocol,
         dataTask: URLSessionDataTaskProtocol,
         didReceive response: URLResponse,
-        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
     ) {
         executionSerializer.dispatch {
             if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
@@ -89,7 +89,7 @@ final class StreamingSession<Interpreter: StreamInterpreter>: NSObject, Identifi
     func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
         guard let sslDelegate else { return completionHandler(.performDefaultHandling, nil) }
         sslDelegate.urlSession(session, didReceive: challenge, completionHandler: completionHandler)

--- a/Sources/OpenAI/Private/URLSessionDataDelegateForwarder.swift
+++ b/Sources/OpenAI/Private/URLSessionDataDelegateForwarder.swift
@@ -26,11 +26,11 @@ final class URLSessionDataDelegateForwarder: NSObject, URLSessionDataDelegate {
         target.urlSession(session, dataTask: dataTask, didReceive: data)
     }
     
-    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         target.urlSession(session, didReceive: challenge, completionHandler: completionHandler)
     }
     
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void) {
         target.urlSession(session, dataTask: dataTask, didReceive: response, completionHandler: completionHandler)
     }
 }

--- a/Sources/OpenAI/Private/URLSessionDelegateProtocol.swift
+++ b/Sources/OpenAI/Private/URLSessionDelegateProtocol.swift
@@ -17,7 +17,7 @@ protocol URLSessionDelegateProtocol: Sendable { // Sendable to make a better mat
     func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     )
 }
 
@@ -28,6 +28,6 @@ protocol URLSessionDataDelegateProtocol: URLSessionDelegateProtocol {
         _ session: URLSessionProtocol,
         dataTask: URLSessionDataTaskProtocol,
         didReceive response: URLResponse,
-        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
     )
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Put Sendable into `URLSessionDataDelegateProtocol` methods that have completion. This wouldn't go against actual delegates as they have it the same:
<img width="1085" alt="Screenshot 2025-06-29 at 01 05 32" src="https://github.com/user-attachments/assets/15cb8fe8-92d2-4c01-b753-77769794fcbd" />
<img width="1067" alt="Screenshot 2025-06-29 at 01 04 56" src="https://github.com/user-attachments/assets/e3b0a4db-0748-4aff-bcac-0adcb36c7e74" />

## Why

To fix the warning about passing non-sendable closure
