### PR TITLE
Add ServiceTier on_demand case

### DIFF
--- a/Sources/OpenAI/Public/Models/Types/ServiceTier.swift
+++ b/Sources/OpenAI/Public/Models/Types/ServiceTier.swift
@@ -11,4 +11,5 @@ public enum ServiceTier: String, Codable, Hashable, Sendable, CaseIterable {
     case auto = "auto"
     case defaultTier = "default"
     case flexTier = "flex"
+    case onDemand = "on_demand"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What
Add `on_demand` ServiceTier case. Another solution - change `ServiceTier` enum usage to just `String`

## Why
Some API Providers (such as `groq`) can return `on_demand` service_tier, and now decoding fails and error is thrown. 

## Affected Areas

<!-- Please describe what parts of the library are affected by the change -->
