### PR TITLE
Add GPT-5 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,11 @@ Models are represented as a typealias `typealias Model = String`.
 
 ```swift
 public extension Model {
+    static let gpt5 = "gpt-5"
+    static let gpt5_mini = "gpt-5-mini"
+    static let gpt5_nano = "gpt-5-nano"
+    static let gpt5_chat = "gpt-5-chat"
+    
     static let gpt4_1 = "gpt-4.1"
     static let gpt4_1_mini = "gpt-4.1-mini"
     static let gpt4_1_nano = "gpt-4.1-nano"

--- a/Sources/OpenAI/Public/Models/Models/Models.swift
+++ b/Sources/OpenAI/Public/Models/Models/Models.swift
@@ -53,6 +53,20 @@ public extension Model {
     @available(*, deprecated, message: "On April 14th, 2025, developers were notified that the gpt-4.5-preview model is deprecated and will be removed from the API in the coming months. Recommended replacement: gpt-4.1")
     static let gpt4_5_preview = "gpt-4.5-preview"
 
+    // GPT-5
+
+    /// `gpt-5` OpenAI's best AI system with significant leap in intelligence, designed for logic and multi-step tasks with deep reasoning
+    static let gpt5 = "gpt-5"
+
+    /// `gpt-5-mini` Lightweight GPT-5 version for cost-sensitive applications
+    static let gpt5_mini = "gpt-5-mini"
+
+    /// `gpt-5-nano` Optimized for ultra-low latency and fast execution
+    static let gpt5_nano = "gpt-5-nano"
+
+    /// `gpt-5-chat` Built for advanced, natural, multimodal conversations
+    static let gpt5_chat = "gpt-5-chat"
+
     // GPT-4.1
 
     /// `gpt-4.1` Smartest model for complex tasks
@@ -247,7 +261,7 @@ public extension Model {
             // reasoning
             .o4_mini, o3, o3_mini, .o1,
             // flagship
-            .gpt4_1, .gpt4_o, .gpt_4o_audio_preview, chatgpt_4o_latest,
+            .gpt5, .gpt5_mini, .gpt5_nano, .gpt5_chat, .gpt4_1, .gpt4_o, .gpt_4o_audio_preview, chatgpt_4o_latest,
             // cost-optimized
             .gpt4_1_mini, .gpt4_1_nano, .gpt4_o_mini, .gpt_4o_mini_audio_preview,
             // tool-specific
@@ -260,7 +274,7 @@ public extension Model {
             // reasoning
             .o4_mini, .o3, .o3_mini, .o1, .o1_pro,
             // flagship
-            .gpt4_1, .gpt4_o, .chatgpt_4o_latest,
+            .gpt5, .gpt5_mini, .gpt5_nano, .gpt5_chat, .gpt4_1, .gpt4_o, .chatgpt_4o_latest,
             // cost-optimized
             .gpt4_1_mini, .gpt4_1_nano, .gpt4_o_mini,
             .gpt4_turbo, .gpt4, .gpt3_5Turbo,


### PR DESCRIPTION
## What

Add new GPT-5 models: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`

## Details

OpenAI released GPT-5 in August 2025 with four model variants:

- **gpt-5**: OpenAI's best AI system with significant leap in intelligence, designed for logic and multi-step tasks with deep reasoning
- **gpt-5-mini**: Lightweight version for cost-sensitive applications
- **gpt-5-nano**: Optimized for ultra-low latency and fast execution  
- **gpt-5-chat**: Built for advanced, natural, multimodal conversations

This PR adds these models to both the Models.swift file and updates the README documentation, following the same pattern as the GPT-4.1 models addition.

## Changes Made

- Added GPT-5 model constants in `Sources/OpenAI/Public/Models/Models/Models.swift`
- Updated both `chatCompletionsEndpoint` and `responsesEndpoint` model sets to include the new models
- Updated README.md with the new model constants in the documentation

## Testing

The changes only add new model string constants and don't affect existing functionality.