### PR TITLE
Update LinkPreview.swift

### DIFF
--- a/Demo/DemoChat/Sources/UI/Images/LinkPreview.swift
+++ b/Demo/DemoChat/Sources/UI/Images/LinkPreview.swift
@@ -18,16 +18,14 @@ struct LinkPreview: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: UIViewType, context: Context) {
-        LPMetadataProvider().startFetchingMetadata(for: previewURL) { metadata, error in
-            if let error = error {
-                print(error.localizedDescription)
-                return
-            }
-            guard let metadata = metadata else {
-                print("Metadata missing for \(previewURL.absoluteString)")
-                return
-            }
-            uiView.metadata = metadata
+        Task { @MainActor in
+            uiView.metadata = try await fetchMetadata()
         }
     }
+    
+    private func fetchMetadata() async throws -> LPLinkMetadata{
+        let metadata = try await LPMetadataProvider().startFetchingMetadata(for: previewURL)
+        return metadata
+    }
 }
+


### PR DESCRIPTION
**Fix Xcode 26.0 Swift Concurrency error** 

<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

* Refactor `LinkPreview` to use Swift Concurrency.
* Fetch metadata with `async/await` and set `LPLinkView.metadata` on the main actor:

  * `Task { @MainActor in uiView.metadata = try await fetchMetadata() }`
  * Introduce `fetchMetadata() async throws -> LPLinkMetadata`.

## Why

* In Xcode 26.0 with stricter concurrency checks, the previous completion-handler approach attempted to set `uiView.metadata` (a `@MainActor`-isolated property) from a `@Sendable`/background context, triggering:
  *“Main actor-isolated property 'metadata' cannot be mutated from a Sendable closure.”*
* Using `async/await` removes the sendable-closure issue and guarantees UI updates occur on the main actor, aligning with Swift 6 concurrency rules.

## Affected Areas

* `LinkPreview.swift` only.
* No behavioral change to the UI; thread-safety and compile-time correctness improved.
* Note: Requires async/await (iOS 15+/macOS 12+).
