### PR TITLE
Make ChoiceDeltaToolCall.index optional

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatStreamResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatStreamResult.swift
@@ -71,7 +71,7 @@ public struct ChatStreamResult: Codable, Equatable, Sendable {
 
             public struct ChoiceDeltaToolCall: Codable, Equatable, Sendable {
 
-                public let index: Int
+                public let index: Int?
                 /// The ID of the tool call.
                 public let id: String?
                 /// The function that the model called.


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Make ChoiceDeltaToolCall.index optional

## Why
According to the OpenAI documentation, this property is not required in the response. ChatGPT always returns the index property, but some other providers omit it.