### PR TITLE
Fix: Return after decoding ResponseStreamEvent successfully

### DIFF
--- a/Sources/OpenAI/Public/Schemas/Facade/ResponseStreamEvent.swift
+++ b/Sources/OpenAI/Public/Schemas/Facade/ResponseStreamEvent.swift
@@ -232,6 +232,7 @@ public enum ResponseStreamEvent: Codable, Equatable, Sendable {
             default:
                 throw ResponseStreamEventDecodingError.unknownEventType(responseEvent.type)
             }
+            return
         } catch {
             // Do nothing, will try other coding types
         }
@@ -240,6 +241,7 @@ public enum ResponseStreamEvent: Codable, Equatable, Sendable {
             // Decoding Output Item events
             let outputItemAddedEvent = try ResponseOutputItemAddedEvent(from: decoder)
             self = .outputItem(.added(outputItemAddedEvent))
+            return
         } catch {
             // Do nothing, will try other coding types
         }
@@ -248,6 +250,7 @@ public enum ResponseStreamEvent: Codable, Equatable, Sendable {
             // Decoding Output Item events
             let outputItemDoneEvent = try ResponseOutputItemDoneEvent(from: decoder)
             self = .outputItem(.done(outputItemDoneEvent))
+            return
         } catch {
             // Do nothing, will try other coding types
         }
@@ -267,6 +270,7 @@ public enum ResponseStreamEvent: Codable, Equatable, Sendable {
             case .done(let doneEvent):
                 self = .mcpCallArguments(.done(doneEvent))
             }
+            return
         } catch {
             //
         }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Return after decoding a ResponseStreamEvent successfully, instead of continuing to attempt other decoding strategies.

## Why

Previously was seeing many decoding errors because the decoding logic would continue instead of returning.

## Affected Areas

Responses API with Streaming
