### PR TITLE
Add 'minimal' reasoning effort

### DIFF
--- a/Sources/OpenAI/Public/Models/ChatQuery.swift
+++ b/Sources/OpenAI/Public/Models/ChatQuery.swift
@@ -15,7 +15,7 @@ public struct ChatQuery: Equatable, Codable, Streamable, Sendable {
     public let messages: [Self.ChatCompletionMessageParam]
     /// Model ID used to generate the response, like `gpt-4o` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](https://platform.openai.com/docs/models) to browse and compare available models.
     public let model: Model
-    /// Constrains effort on reasoning for [reasoning models](https://platform.openai.com/docs/guides/reasoning). Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+    /// Constrains effort on reasoning for [reasoning models](https://platform.openai.com/docs/guides/reasoning). Currently supported values are minimal, low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
     ///
     /// - Note: o-series models only
     public let reasoningEffort: ReasoningEffort?
@@ -922,6 +922,7 @@ public struct ChatQuery: Equatable, Codable, Streamable, Sendable {
     }
     
     public enum ReasoningEffort: Codable, Equatable, Sendable {
+        case minimal
         case low
         case medium
         case high
@@ -934,6 +935,8 @@ public struct ChatQuery: Equatable, Codable, Streamable, Sendable {
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.singleValueContainer()
             switch self {
+            case .minimal:
+                try container.encode("minimal")
             case .low:
                 try container.encode("low")
             case .medium:
@@ -949,6 +952,8 @@ public struct ChatQuery: Equatable, Codable, Streamable, Sendable {
             let container = try decoder.singleValueContainer()
             let rawValue = try container.decode(String.self)
             switch rawValue {
+            case "minimal":
+                self = .minimal
             case "low":
                 self = .low
             case "medium":

--- a/Sources/OpenAI/Public/Schemas/Generated/Components.swift
+++ b/Sources/OpenAI/Public/Schemas/Generated/Components.swift
@@ -4861,13 +4861,14 @@ public enum Components {
         ///
         /// Constrains effort on reasoning for
         /// [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-        /// Currently supported values are `low`, `medium`, and `high`. Reducing
+        /// Currently supported values are `minimal`, `low`, `medium`, and `high`. Reducing
         /// reasoning effort can result in faster responses and fewer tokens used
         /// on reasoning in a response.
         ///
         ///
         /// - Remark: Generated from `#/components/schemas/ReasoningEffort`.
         @frozen public enum ReasoningEffort: String, Codable, Hashable, Sendable, CaseIterable {
+            case minimal = "minimal"
             case low = "low"
             case medium = "medium"
             case high = "high"

--- a/Tests/OpenAITests/OpenAITestsDecoder.swift
+++ b/Tests/OpenAITests/OpenAITestsDecoder.swift
@@ -347,6 +347,43 @@ class OpenAITestsDecoder: XCTestCase {
         XCTAssertEqual(chatQueryAsDict, expectedValueAsDict)
     }
     
+    func testChatQueryWithReasoningEffortMinimal() throws {
+        let chatQuery = ChatQuery(
+            messages: [
+                .init(role: .user, content: "Who are you?")!
+            ],
+            model: .gpt4,
+            reasoningEffort: .minimal
+        )
+        let expectedValue = """
+            {
+                "model": "gpt-4",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Who are you?"
+                    }
+                ],
+                "reasoning_effort": "minimal",
+                "stream": false
+            }
+            """
+        
+        let chatQueryAsDict = try jsonDataAsNSDictionary(JSONEncoder().encode(chatQuery))
+        let expectedValueAsDict = try jsonDataAsNSDictionary(expectedValue.data(using: .utf8)!)
+        
+        XCTAssertEqual(chatQueryAsDict, expectedValueAsDict)
+    }
+
+    func testReasoningEffortDecodingMinimal() throws {
+        let json = """
+        { "effort": "minimal" }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Components.Schemas.Reasoning.self, from: data)
+        XCTAssertEqual(decoded.effort, .minimal)
+    }
+    
     func testEmbeddings() async throws {
         let data = """
         {


### PR DESCRIPTION
OpenAI added reasoning effort level minimal:

<br/>

<img width="337" height="307" alt="image" src="https://github.com/user-attachments/assets/f8fd9d94-ed25-46b4-8033-650698822689" />

<br/><br/>

- Extend ChatQuery.ReasoningEffort with .minimal
- Extend Components.Schemas.ReasoningEffort with .minimal
- Update comments to mention minimal
- Add tests for encoding/decoding minimal effort

AI assisted PR (codex)