### PR TITLE
Fix: Consider event type in data payload when processing model response streams

### DIFF
--- a/Sources/OpenAI/Private/Streaming/ModelResponseEventsStreamInterpreter.swift
+++ b/Sources/OpenAI/Private/Streaming/ModelResponseEventsStreamInterpreter.swift
@@ -55,22 +55,30 @@ final class ModelResponseEventsStreamInterpreter: @unchecked Sendable, StreamInt
     }
     
     private func processEvent(_ event: ServerSentEventsStreamParser.Event) throws {
-        var finalEvent = event
-        if event.eventType == "response.output_text.annotation.added" {
-            // Remove when they have fixed (unified)!
-            //
-            // By looking at [API Reference](https://platform.openai.com/docs/api-reference/responses-streaming/response/output_text_annotation/added)
-            // and generated type `Schemas.ResponseOutputTextAnnotationAddedEvent`
-            // We can see that "output_text.annotation" is incorrect, whereas output_text_annotation is the correct one
-            let fixedDataString = event.decodedData.replacingOccurrences(of: "response.output_text.annotation.added", with: "response.output_text_annotation.added")
-            finalEvent = .init(id: event.id, data: fixedDataString.data(using: .utf8) ?? event.data, decodedData: fixedDataString, eventType: "response.output_text_annotation.added", retry: event.retry)
+        var eventType = event.eventType
+
+        if eventType == "message" { // This is currently the default if no SSE event name is specified
+            struct _TypeEnvelope: Decodable { let type: String }
+
+            if var payloadType = try? JSONDecoder().decode(_TypeEnvelope.self, from: event.data).type {
+                if payloadType == "response.output_text.annotation.added" {
+                    // Remove when they have fixed (unified)!
+                    //
+                    // By looking at [API Reference](https://platform.openai.com/docs/api-reference/responses-streaming/response/output_text_annotation/added)
+                    // and generated type `Schemas.ResponseOutputTextAnnotationAddedEvent`
+                    // We can see that "output_text.annotation" is incorrect, whereas output_text_annotation is the correct one
+                    payloadType = "response.output_text_annotation.added"
+                }
+
+                eventType = payloadType
+            }
+        }
+
+        guard let modelResponseEventType = ModelResponseStreamEventType(rawValue: eventType) else {
+            throw InterpreterError.unknownEventType(eventType)
         }
         
-        guard let modelResponseEventType = ModelResponseStreamEventType(rawValue: finalEvent.eventType) else {
-            throw InterpreterError.unknownEventType(finalEvent.eventType)
-        }
-        
-        let responseStreamEvent = try responseStreamEvent(modelResponseEventType: modelResponseEventType, data: finalEvent.data)
+        let responseStreamEvent = try responseStreamEvent(modelResponseEventType: modelResponseEventType, data: event.data)
         onEventDispatched?(responseStreamEvent)
     }
     

--- a/Sources/OpenAI/Private/Streaming/ModelResponseEventsStreamInterpreter.swift
+++ b/Sources/OpenAI/Private/Streaming/ModelResponseEventsStreamInterpreter.swift
@@ -58,7 +58,8 @@ final class ModelResponseEventsStreamInterpreter: @unchecked Sendable, StreamInt
         let finalEvent = event.fixMappingError()
         var eventType = finalEvent.eventType
 
-        // "message" is currently the default if no SSE event name is specified
+        /// If the SSE `event` property is not specified by the provider service, our parser defaults it to "message" which is not a valid model response type.
+    /// In this case we check the `data.type` property for a valid model response type.
         if eventType == "message" || eventType.isEmpty,
            let payloadEventType = finalEvent.getPayloadType() {
             eventType = payloadEventType

--- a/Sources/OpenAI/Private/Streaming/ModelResponseEventsStreamInterpreter.swift
+++ b/Sources/OpenAI/Private/Streaming/ModelResponseEventsStreamInterpreter.swift
@@ -59,7 +59,7 @@ final class ModelResponseEventsStreamInterpreter: @unchecked Sendable, StreamInt
         var eventType = finalEvent.eventType
 
         /// If the SSE `event` property is not specified by the provider service, our parser defaults it to "message" which is not a valid model response type.
-    /// In this case we check the `data.type` property for a valid model response type.
+        /// In this case we check the `data.type` property for a valid model response type.
         if eventType == "message" || eventType.isEmpty,
            let payloadEventType = finalEvent.getPayloadType() {
             eventType = payloadEventType

--- a/Tests/OpenAITests/MockServerSentEvent.swift
+++ b/Tests/OpenAITests/MockServerSentEvent.swift
@@ -20,4 +20,17 @@ struct MockServerSentEvent {
     static func chatCompletionError() -> Data {
         "{\n    \"error\": {\n        \"message\": \"The model `o3-mini` does not exist or you do not have access to it.\",\n        \"type\": \"invalid_request_error\",\n        \"param\": null,\n        \"code\": \"model_not_found\"\n    }\n}\n".data(using: .utf8)!
     }
+
+    static func responseOutputTextDelta(
+        itemId: String = "msg_1",
+        outputIndex: Int = 0,
+        contentIndex: Int = 0,
+        delta: String = "Hi",
+        sequenceNumber: Int = 1
+    ) -> Data {
+        let json = """
+        {"type":"response.output_text.delta","output_index":\(outputIndex),"item_id":"\(itemId)","content_index":\(contentIndex),"delta":"\(delta)","sequence_number":\(sequenceNumber)}
+        """
+        return "data: \(json)\n\n".data(using: .utf8)!
+    }
 }

--- a/Tests/OpenAITests/MockServerSentEvent.swift
+++ b/Tests/OpenAITests/MockServerSentEvent.swift
@@ -21,15 +21,16 @@ struct MockServerSentEvent {
         "{\n    \"error\": {\n        \"message\": \"The model `o3-mini` does not exist or you do not have access to it.\",\n        \"type\": \"invalid_request_error\",\n        \"param\": null,\n        \"code\": \"model_not_found\"\n    }\n}\n".data(using: .utf8)!
     }
 
-    static func responseOutputTextDelta(
+    static func responseStreamEvent(
         itemId: String = "msg_1",
+        payloadType: String,
         outputIndex: Int = 0,
         contentIndex: Int = 0,
-        delta: String = "Hi",
+        delta: String = "",
         sequenceNumber: Int = 1
     ) -> Data {
         let json = """
-        {"type":"response.output_text.delta","output_index":\(outputIndex),"item_id":"\(itemId)","content_index":\(contentIndex),"delta":"\(delta)","sequence_number":\(sequenceNumber)}
+        {"type":"\(payloadType)","output_index":\(outputIndex),"item_id":"\(itemId)","content_index":\(contentIndex),"delta":"\(delta)","sequence_number":\(sequenceNumber)}
         """
         return "data: \(json)\n\n".data(using: .utf8)!
     }

--- a/Tests/OpenAITests/ModelResponseEventsStreamInterpreterTests.swift
+++ b/Tests/OpenAITests/ModelResponseEventsStreamInterpreterTests.swift
@@ -56,8 +56,9 @@ final class ModelResponseEventsStreamInterpreterTests: XCTestCase {
         }
 
         interpreter.processData(
-            MockServerSentEvent.responseOutputTextDelta(
+            MockServerSentEvent.responseStreamEvent(
                 itemId: "msg_1",
+                payloadType: "response.output_text.delta",
                 outputIndex: 0,
                 contentIndex: 0,
                 delta: "Hi",

--- a/Tests/OpenAITests/ModelResponseEventsStreamInterpreterTests.swift
+++ b/Tests/OpenAITests/ModelResponseEventsStreamInterpreterTests.swift
@@ -39,4 +39,48 @@ final class ModelResponseEventsStreamInterpreterTests: XCTestCase {
         XCTAssertNotNil(receivedError, "Expected an error to be received, but got nil.")
         XCTAssertTrue(receivedError is APIErrorResponse, "Expected received error to be of type APIErrorResponse.")
     }
+
+    func testParsesOutputTextDeltaUsingPayloadType() async throws {
+        let expectation = XCTestExpectation(description: "OutputText delta event received")
+        var receivedEvent: ResponseStreamEvent?
+
+        interpreter.setCallbackClosures { event in
+            Task {
+                await MainActor.run {
+                    receivedEvent = event
+                    expectation.fulfill()
+                }
+            }
+        } onError: { error in
+            XCTFail("Unexpected error received: \(error)")
+        }
+
+        interpreter.processData(
+            MockServerSentEvent.responseOutputTextDelta(
+                itemId: "msg_1",
+                outputIndex: 0,
+                contentIndex: 0,
+                delta: "Hi",
+                sequenceNumber: 1
+            )
+        )
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        guard let receivedEvent else {
+            XCTFail("No event received")
+            return
+        }
+
+        switch receivedEvent {
+        case .outputText(.delta(let deltaEvent)):
+            XCTAssertEqual(deltaEvent.itemId, "msg_1")
+            XCTAssertEqual(deltaEvent.outputIndex, 0)
+            XCTAssertEqual(deltaEvent.contentIndex, 0)
+            XCTAssertEqual(deltaEvent.delta, "Hi")
+            XCTAssertEqual(deltaEvent.sequenceNumber, 1)
+        default:
+            XCTFail("Expected .outputText(.delta), got \(receivedEvent)")
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What
Enable the parsing of `type` property inside of the event.data object for mapping model responses.

## Why
Parsing of streamed events from /responses endpoint only looks at the type property of the SSE event itself, and not at the type property inside the events data payload. As a result it is not possible to parse properly formed events.

When attempting to stream events from the /responses api using OpenAI.responses.createResponseStreaming() it seems there is a bug that prevents the events from being processed.

Despite receiving properly formatted events, ie:
```
data: {"type":"response.output_text.delta","sequence_number":0,"delta":"#", ...}
```

ModelResponseEventsStreamInterpreter.processEvent for:
```
Printing description of event:
▿ Event
  - id : nil
  ▿ data : 69 bytes
    - count : 69
    ▿ pointer : 0x000000011450ec90
      - pointerValue : 4635815056
  - decodedData : "{\"type\":\"response.output_text.delta\",\"sequence_number\":0,\"delta\":\"#\"}"
  - eventType : "message"
  - retry : nil
```

Produces error:
```
Printing description of error:
▿ InterpreterError
  - unknownEventType : "message"
```

The "message" event type is not present in the event received and seems to come from line 207 of the `ServerSentEventsStreamParser` that sets a default event type (for the sse event) to "message" by default if there is no value in the event *field* of the sse event.

I believe the bug is that `ModelResponseEventsStreamInterpreter.processEvent` refers to this default value for the SSE event field when attempting to parse a `ModelResponseStreamEventType` when it should be using the `type` property inside the SSE event's data object as per the openAI spec. We can see is "response.output_text.delta" in the example above.

## Affected Areas

This updates how streamed model responses are parsed and processed.
