### PR TITLE
Make index of ChoiceDeltaToolCall required

### DIFF
--- a/Sources/OpenAI/Private/KeyedDecodingContainer+ParsingOptions.swift
+++ b/Sources/OpenAI/Private/KeyedDecodingContainer+ParsingOptions.swift
@@ -16,6 +16,10 @@ extension KeyedDecodingContainer {
         try self.decode(TimeInterval.self, forKey: key, parsingOptions: parsingOptions, defaultValue: 0)
     }
     
+    func decodeInt(forKey key: KeyedDecodingContainer<K>.Key, parsingOptions: ParsingOptions) throws -> Int {
+        try self.decode(Int.self, forKey: key, parsingOptions: parsingOptions, defaultValue: 0)
+    }
+    
     func decode<T: Decodable>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key, parsingOptions: ParsingOptions, defaultValue: T) throws -> T {
         do {
             return try decode(T.self, forKey: key)

--- a/Sources/OpenAI/Public/Models/ChatStreamResult.swift
+++ b/Sources/OpenAI/Public/Models/ChatStreamResult.swift
@@ -71,7 +71,7 @@ public struct ChatStreamResult: Codable, Equatable, Sendable {
 
             public struct ChoiceDeltaToolCall: Codable, Equatable, Sendable {
 
-                public let index: Int?
+                public let index: Int
                 /// The ID of the tool call.
                 public let id: String?
                 /// The function that the model called.
@@ -88,6 +88,15 @@ public struct ChatStreamResult: Codable, Equatable, Sendable {
                     self.id = id
                     self.function = function
                     self.type = "function"
+                }
+                
+                public init(from decoder: any Decoder) throws {
+                    let container: KeyedDecodingContainer<ChoiceDeltaToolCall.CodingKeys> = try decoder.container(keyedBy: ChoiceDeltaToolCall.CodingKeys.self)
+                    let parsingOptions = decoder.userInfo[.parsingOptions] as? ParsingOptions ?? []
+                    self.index = try container.decodeInt(forKey: ChoiceDeltaToolCall.CodingKeys.index, parsingOptions: parsingOptions)
+                    self.id = try container.decodeIfPresent(String.self, forKey: ChoiceDeltaToolCall.CodingKeys.id)
+                    self.function = try container.decodeIfPresent(ChoiceDeltaToolCallFunction.self, forKey: ChoiceDeltaToolCall.CodingKeys.function)
+                    self.type = try container.decodeIfPresent(String.self, forKey: ChoiceDeltaToolCall.CodingKeys.type)
                 }
 
                 public struct ChoiceDeltaToolCallFunction: Codable, Equatable, Sendable {


### PR DESCRIPTION
## What

Make index of ChoiceDeltaToolCall required, but only in strict mode. 0 would be used in relaxed mode if not found

## Why

Both in OpenAI doc and its OpenAPI spec this field is marked as required, so it should be the same in our code. Use `relaxed` mode for working with other providers.

<img width="765" height="510" alt="Screenshot 2025-09-25 at 18 48 46" src="https://github.com/user-attachments/assets/eedea00b-ddce-4bc9-aa37-27ec5eb23742" />

## Affected Areas

<!-- Please describe what parts of the library are affected by the change -->
