### PR TITLE
Add Double/Int overloads for JSON schema numeric constraints

### DIFF
--- a/Sources/OpenAI/Public/JSONSchema/JSONDocument.swift
+++ b/Sources/OpenAI/Public/JSONSchema/JSONDocument.swift
@@ -17,6 +17,7 @@ public protocol JSONDocument: Codable, Hashable, Sendable {
 /// A JSON "null" value
 struct JSONNullValue: JSONDocument {}
 extension Int: JSONDocument {}
+extension Double: JSONDocument {}
 extension String: JSONDocument {}
 extension Bool: JSONDocument {}
 /// [number](https://json-schema.org/draft/2020-12/json-schema-core#section-4.2.1-3.10)

--- a/Sources/OpenAI/Public/JSONSchema/JSONSchemaField.swift
+++ b/Sources/OpenAI/Public/JSONSchema/JSONSchemaField.swift
@@ -361,7 +361,15 @@ public struct JSONSchemaField {
     /// ### Summary
     /// A numeric instance is valid only if division by this keyword’s value results in an integer.
     public static func multipleOf(_ value: Decimal) -> JSONSchemaField {
-        .init(keyword: "maximum", value: .init(value))
+        .init(keyword: "multipleOf", value: .init(value))
+    }
+
+    public static func multipleOf(_ value: Double) -> JSONSchemaField {
+        .init(keyword: "multipleOf", value: .init(value))
+    }
+
+    public static func multipleOf(_ value: Int) -> JSONSchemaField {
+        .init(keyword: "multipleOf", value: .init(value))
     }
     
     /// ### Kind
@@ -373,6 +381,14 @@ public struct JSONSchemaField {
     /// ### Summary
     /// Validation succeeds if the numeric instance is less than or equal to the given number.
     public static func maximum(_ value: Decimal) -> JSONSchemaField {
+        .init(keyword: "maximum", value: .init(value))
+    }
+
+    public static func maximum(_ value: Double) -> JSONSchemaField {
+        .init(keyword: "maximum", value: .init(value))
+    }
+
+    public static func maximum(_ value: Int) -> JSONSchemaField {
         .init(keyword: "maximum", value: .init(value))
     }
     
@@ -387,6 +403,14 @@ public struct JSONSchemaField {
     public static func exclusiveMaximum(_ value: Decimal) -> JSONSchemaField {
         .init(keyword: "exclusiveMaximum", value: .init(value))
     }
+
+    public static func exclusiveMaximum(_ value: Double) -> JSONSchemaField {
+        .init(keyword: "exclusiveMaximum", value: .init(value))
+    }
+
+    public static func exclusiveMaximum(_ value: Int) -> JSONSchemaField {
+        .init(keyword: "exclusiveMaximum", value: .init(value))
+    }
     
     /// ### Kind
     /// Assertion
@@ -399,6 +423,14 @@ public struct JSONSchemaField {
     public static func minimum(_ value: Decimal) -> JSONSchemaField {
         .init(keyword: "minimum", value: .init(value))
     }
+
+    public static func minimum(_ value: Double) -> JSONSchemaField {
+        .init(keyword: "minimum", value: .init(value))
+    }
+
+    public static func minimum(_ value: Int) -> JSONSchemaField {
+        .init(keyword: "minimum", value: .init(value))
+    }
     
     /// ### Kind
     /// Assertion
@@ -409,6 +441,14 @@ public struct JSONSchemaField {
     /// ### Summary
     /// Validation succeeds if the numeric instance is greater than the given number.
     public static func exclusiveMinimum(_ value: Decimal) -> JSONSchemaField {
+        .init(keyword: "exclusiveMinimum", value: .init(value))
+    }
+
+    public static func exclusiveMinimum(_ value: Double) -> JSONSchemaField {
+        .init(keyword: "exclusiveMinimum", value: .init(value))
+    }
+
+    public static func exclusiveMinimum(_ value: Int) -> JSONSchemaField {
         .init(keyword: "exclusiveMinimum", value: .init(value))
     }
     


### PR DESCRIPTION
## What

Support sending Ints & Doubles as JSON schema constraints.

## Why

The SDK currently doesn’t handle numerical constraints in structured outputs correctly.
For example, using `JSONField.maximum(Decimal(N))` gets translated into:

```json
"maximum" : {
    "exponent" : 2,
    "isCompact" : true,
    "length" : 1,
    "isNegative" : false,
    "mantissa" : [1, 0, 0, 0, 0, 0, 0, 0]
}
```

a format that OpenAI does not support.

## Affected Areas

`JsonSchema/` module.