### PR TITLE
Improve ChatQuery description readability

### DIFF
--- a/Demo/DemoChat/Package.resolved
+++ b/Demo/DemoChat/Package.resolved
@@ -1,0 +1,123 @@
+{
+  "originHash" : "bcd79666ae410601a4f1ded1094921cb30aa100078efb734690a128ae00006a7",
+  "pins" : [
+    {
+      "identity" : "activityindicatorview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/ActivityIndicatorView",
+      "state" : {
+        "revision" : "36140867802ae4a1d2b11490bcbbefe058001d14",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "anchoredpopup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/AnchoredPopup.git",
+      "state" : {
+        "revision" : "d7478c34e761725ff06ad74e44e675d0d56a4150",
+        "version" : "1.0.7"
+      }
+    },
+    {
+      "identity" : "chat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/Chat.git",
+      "state" : {
+        "revision" : "f5d93619556fbb988985c3a5fe2444ce96190f39",
+        "version" : "2.7.4"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "ca2a9d90cbe49e09b92f4b6ebd922c03ebea51d0",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "giphy-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Giphy/giphy-ios-sdk",
+      "state" : {
+        "revision" : "37f5b1ff6cf8bc4a78c0bc5eb1b814381bac9580",
+        "version" : "2.2.16"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher",
+      "state" : {
+        "revision" : "d30a5fad881137e2267f96a8e3fc35c58999bb94",
+        "version" : "8.6.2"
+      }
+    },
+    {
+      "identity" : "libwebp-xcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/libwebp-Xcode",
+      "state" : {
+        "revision" : "0d60654eeefd5d7d2bef3835804892c40225e8b2",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "mediapicker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/MediaPicker.git",
+      "state" : {
+        "revision" : "fd71c0b560aa79eee1b87f73ce93fac5576a01df",
+        "version" : "3.2.4"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "7722cf8eac05c1f1b5b05895b04cfcc29576d9be",
+        "version" : "1.8.3"
+      }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "c0407a0b52677cb395d824cac2879b963075ba8c",
+        "version" : "0.10.2"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+        "version" : "1.6.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Demo/DemoChat/Sources/ResponsesStore.swift
+++ b/Demo/DemoChat/Sources/ResponsesStore.swift
@@ -656,6 +656,8 @@ public final class ResponsesStore: ObservableObject {
         case .mcpToolCall(_ /* let mcpCall */):
             // MCP tool call in progress - no UI action needed
             break
+        case .reasoning(let reasoningItem):
+            print("reasoning output item added, summary: \(reasoningItem.summary)")
         default:
             throw StoreError.unhandledOutputItem(outputItem)
         }
@@ -693,6 +695,8 @@ public final class ResponsesStore: ObservableObject {
             if let output = mcpCall.output {
                 print("Result: \(output)")
             }
+        case .reasoning(let reasoningItem):
+            print("reasoning output item done, summary: \(reasoningItem.summary)")
         default:
             throw StoreError.unhandledOutputItem(outputItem)
         }

--- a/Sources/OpenAI/Private/ChatQuery+CustomStringConvertible.swift
+++ b/Sources/OpenAI/Private/ChatQuery+CustomStringConvertible.swift
@@ -1,0 +1,31 @@
+//
+//  ChatQuery+CustomStringConvertible.swift
+//  OpenAI
+//
+//  Created by Oleksii Nezhyborets on 19.11.2025.
+//
+
+import Foundation
+
+extension ChatQuery: CustomStringConvertible, CustomDebugStringConvertible {
+
+    public var description: String { jsonDescription(prettyPrinted: true) }
+
+    public var debugDescription: String { jsonDescription(prettyPrinted: true) }
+
+    private func jsonDescription(prettyPrinted: Bool) -> String {
+        let encoder = JSONEncoder()
+        var formatting: JSONEncoder.OutputFormatting = [.sortedKeys]
+        if prettyPrinted {
+            formatting.insert(.prettyPrinted)
+        }
+        encoder.outputFormatting = formatting
+        guard
+            let data = try? encoder.encode(self),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return "ChatQuery(model: \(model), messages: \(messages.count))"
+        }
+        return string
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to MacPaw/OpenAI 😊 -->

## What

Improve ChatQuery description readability

## Why

For easier debug. Without it printing an instance of ChatQuery would lead to unreadable text with too many types in it like `OpenAI.ChatQuery.ChatCompletionMessageParam.developer(OpenAI.ChatQuery.ChatCompletionMessageParam.DeveloperMessageParam` etc.

## Affected Areas

`ChatQuery.swift`
Also added a case to demo app so that it doesn't fail on an expected case
