### PR TITLE
docs(security): direct vulnerability reports to private channel only

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,8 +15,9 @@ Report (suspected) security vulnerabilities privately to
 **[support@macpaw.com](mailto:support@macpaw.com)**.
 
 If [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
-is enabled on the repository, you can also use GitHub's
-["Report a vulnerability"](https://github.com/MacPaw/OpenAI/security/advisories/new) form.
+is enabled on the repository, you can also use the
+["Security"](https://github.com/MacPaw/OpenAI/security) tab and click
+the **Report a vulnerability** button.
 
 Please include:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,11 +7,27 @@
 | 0.x.x   | :white_check_mark: |
 | 1.x.x   | :white_check_mark: |
 
-## Reporting a Bug
-
-Report security bugs by creating [issues](https://github.com/MacPaw/OpenAI/issues).
-
 ## Reporting a Vulnerability
 
-Please report (suspected) security vulnerabilities to
-**[support@macpaw.com](mailto:support@macpaw.com)**. 
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Report (suspected) security vulnerabilities privately to
+**[support@macpaw.com](mailto:support@macpaw.com)**.
+
+If [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+is enabled on the repository, you can also use GitHub's
+["Report a vulnerability"](https://github.com/MacPaw/OpenAI/security/advisories/new) form.
+
+Please include:
+
+- A description of the issue and its potential impact.
+- Steps to reproduce, a proof-of-concept, or affected code paths.
+- The version(s) of the library you tested against.
+
+We will acknowledge your report, investigate, and coordinate a fix and
+disclosure timeline with you.
+
+## Reporting Non-Security Bugs
+
+For non-security bugs, please open a regular
+[GitHub issue](https://github.com/MacPaw/OpenAI/issues).


### PR DESCRIPTION
## Summary

- Removes the "Report security bugs by creating issues" line in `SECURITY.md`, which directly contradicted the private email path below it. Anyone following that instruction would publicly disclose a vulnerability before a fix existed.
- Restructures the policy so the private channel is the primary, prominent path, with an explicit "do not report publicly" warning.
- Keeps `support@macpaw.com` as the canonical contact, and mentions GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) as a conditional option (so the doc stays accurate whether or not the feature is enabled on the repo).
- Adds a short "what to include" list to make triage easier, and demotes non-security bugs to their own section.

No code changes; docs only.

## Test plan

- [ ] Render `SECURITY.md` on GitHub and confirm the warning is prominent and links resolve.
- [ ] Confirm with the security team whether to enable GitHub's private vulnerability reporting, so the conditional sentence becomes unconditional in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)