### PR TITLE
feat(responses): add prompt_cache_key to CreateModelResponseQuery

### DIFF
--- a/Sources/OpenAI/Public/Models/Responses API/CreateModelResponseQuery.swift
+++ b/Sources/OpenAI/Public/Models/Responses API/CreateModelResponseQuery.swift
@@ -63,7 +63,11 @@ public struct CreateModelResponseQuery: Codable, Equatable, Sendable {
     
     /// Reference to a prompt template and its variables. [Learn more](https://platform.openai.com/docs/guides/text?api-mode=responses#reusable-prompts).
     public let prompt: Schemas.Prompt?
-    
+
+    /// Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+    /// Replaces the `user` field. [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
+    public let promptCacheKey: String?
+
     /// **o-series models only**
     ///
     /// Configuration options for [reasoning models](https://platform.openai.com/docs/guides/reasoning).
@@ -137,6 +141,7 @@ public struct CreateModelResponseQuery: Codable, Equatable, Sendable {
         parallelToolCalls: Bool? = nil,
         previousResponseId: String? = nil,
         prompt: Schemas.Prompt? = nil,
+        promptCacheKey: String? = nil,
         reasoning: Schemas.Reasoning? = nil,
         serviceTier: ServiceTier? = nil,
         store: Bool? = nil,
@@ -159,6 +164,7 @@ public struct CreateModelResponseQuery: Codable, Equatable, Sendable {
         self.parallelToolCalls = parallelToolCalls
         self.previousResponseId = previousResponseId
         self.prompt = prompt
+        self.promptCacheKey = promptCacheKey
         self.reasoning = reasoning
         self.serviceTier = serviceTier
         self.store = store
@@ -183,6 +189,7 @@ public struct CreateModelResponseQuery: Codable, Equatable, Sendable {
         case parallelToolCalls = "parallel_tool_calls"
         case previousResponseId = "previous_response_id"
         case prompt
+        case promptCacheKey = "prompt_cache_key"
         case reasoning
         case serviceTier = "service_tier"
         case store

--- a/Tests/OpenAITests/OpenAITestsDecoder.swift
+++ b/Tests/OpenAITests/OpenAITestsDecoder.swift
@@ -895,6 +895,29 @@ class OpenAITestsDecoder: XCTestCase {
         try testEncodedCreateResponseQueryWithVerbosity(data)
     }
 
+    func testCreateResponseQueryEncodesPromptCacheKey() throws {
+        let query = CreateModelResponseQuery(
+            input: .textInput("Hello"),
+            model: .gpt4_o,
+            promptCacheKey: "user-1234"
+        )
+
+        let data = try JSONEncoder().encode(query)
+        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(try XCTUnwrap(dict["prompt_cache_key"] as? String), "user-1234")
+    }
+
+    func testCreateResponseQueryOmitsPromptCacheKeyWhenNil() throws {
+        let query = CreateModelResponseQuery(
+            input: .textInput("Hello"),
+            model: .gpt4_o
+        )
+
+        let data = try JSONEncoder().encode(query)
+        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNil(dict["prompt_cache_key"])
+    }
+
     private func testEncodedChatQueryWithStructuredOutput(_ data: Data) throws {
         let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         XCTAssertEqual(try XCTUnwrap(dict["model"] as? String), "gpt-4o")


### PR DESCRIPTION
## Summary

Closes #386.

OpenAI's Responses API accepts a [`prompt_cache_key`](https://platform.openai.com/docs/guides/prompt-caching) parameter that buckets similar requests together for improved cache hit rates and routing. Previously there was no way to set it from `CreateModelResponseQuery`, forcing users to fork or fall back to lower-level workarounds.

This PR adds a single optional `promptCacheKey: String?` property + matching init parameter (default `nil`) + `CodingKey` mapping to `"prompt_cache_key"`. Pure addition — no existing call site needs to change.

## Test plan

- [x] `testCreateResponseQueryEncodesPromptCacheKey` — when set, the encoded JSON contains `"prompt_cache_key": "user-1234"`.
- [x] `testCreateResponseQueryOmitsPromptCacheKeyWhenNil` — when not provided, the encoded JSON has no `prompt_cache_key` field (verifies we don't accidentally send `null` and pollute requests).
- [x] `swift test` — all 177 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)