### PR TITLE
ci: add Dependabot config for github-actions and swift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "swift"


### PR DESCRIPTION
## Summary

Adds a minimal `.github/dependabot.yml` that opts the repo into weekly Dependabot updates for the two ecosystems it actually uses:

- **`github-actions`** — main supply-chain surface. Once enabled, Dependabot will start opening PRs to bump pinned action versions. (Note: `.github/workflows/codeql.yml` currently uses `github/codeql-action/init@main` and `analyze@main`; once they're pinned to a version tag — that's the change being passed to your security team — Dependabot can keep them current.)
- **`swift`** — currently just `swift-openapi-runtime`, but worth tracking now that there's a config.

### Choices

- **Weekly** (not daily) — daily is noisy for a small dep set.
- **Open PR limit of 5** per ecosystem — generous but not floodable.
- **Commit prefixes** (`ci` / `deps`) — sort cleanly in changelogs and keep the existing convention legible.
- **Labels** (`dependencies`, `github-actions`, `swift`) — Dependabot auto-creates these on first PR if they don't exist.
- **No `reviewers:` field** — branch protection already requires review, and explicit assignment would just add noise. Easy to add later.

### Deliberately not included

- `groups:` for batching minor/patch updates — overkill with one Swift dep.
- `ignore:` rules — premature.

## Test plan

- [ ] Merge, then check the **Insights → Dependency graph → Dependabot** tab on GitHub to confirm both ecosystems are recognized.
- [ ] Within ~24 hours of merge, Dependabot should run an initial scan; any pending updates will appear as PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)