### PR TITLE
Bug: Add missing name field to ResponseFunctionCallArgumentsDoneEvent

### DIFF
--- a/Sources/OpenAI/Public/Schemas/Edited/ResponseFunctionCallArgumentsDoneEvent.swift
+++ b/Sources/OpenAI/Public/Schemas/Edited/ResponseFunctionCallArgumentsDoneEvent.swift
@@ -1,0 +1,78 @@
+//
+//  ResponseFunctionCallArgumentsDoneEvent.swift
+//  OpenAI
+//
+
+/// Remove it once the generated `Components.Schemas.ResponseFunctionCallArgumentsDoneEvent`
+/// includes `name`.
+///
+/// Per the [OpenAI docs](https://developers.openai.com/api/reference/resources/responses/streaming-events#response.function_call_arguments.done),
+/// `response.function_call_arguments.done` carries a `name` identifying the
+/// function whose arguments have been finalized. The OpenAPI spec used to
+/// generate `Components.swift` is missing it, so we extract the type per
+/// CONTRIBUTING.md and add the field here.
+///
+/// Emitted when function-call arguments are finalized.
+///
+/// - Remark: Generated from `#/components/schemas/ResponseFunctionCallArgumentsDoneEvent`.
+public struct ResponseFunctionCallArgumentsDoneEvent: Codable, Hashable, Sendable {
+    /// - Remark: Generated from `#/components/schemas/ResponseFunctionCallArgumentsDoneEvent/type`.
+    @frozen public enum _TypePayload: String, Codable, Hashable, Sendable, CaseIterable {
+        case response_functionCallArguments_done = "response.function_call_arguments.done"
+    }
+    /// - Remark: Generated from `#/components/schemas/ResponseFunctionCallArgumentsDoneEvent/type`.
+    public var _type: _TypePayload
+    /// The ID of the item.
+    ///
+    /// - Remark: Generated from `#/components/schemas/ResponseFunctionCallArgumentsDoneEvent/item_id`.
+    public var itemId: Swift.String
+    /// The index of the output item.
+    ///
+    /// - Remark: Generated from `#/components/schemas/ResponseFunctionCallArgumentsDoneEvent/output_index`.
+    public var outputIndex: Swift.Int
+    /// The sequence number of this event.
+    ///
+    /// - Remark: Generated from `#/components/schemas/ResponseFunctionCallArgumentsDoneEvent/sequence_number`.
+    public var sequenceNumber: Swift.Int
+    /// The function-call arguments.
+    ///
+    /// - Remark: Generated from `#/components/schemas/ResponseFunctionCallArgumentsDoneEvent/arguments`.
+    public var arguments: Swift.String
+    /// The name of the function being called. Optional for forward-compatibility
+    /// with servers that haven't shipped the field on this event yet.
+    ///
+    /// - Remark: Generated from `#/components/schemas/ResponseFunctionCallArgumentsDoneEvent/name`.
+    public var name: Swift.String?
+    /// Creates a new `ResponseFunctionCallArgumentsDoneEvent`.
+    ///
+    /// - Parameters:
+    ///   - _type:
+    ///   - itemId: The ID of the item.
+    ///   - outputIndex: The index of the output item.
+    ///   - sequenceNumber: The sequence number of this event.
+    ///   - arguments: The function-call arguments.
+    ///   - name: The name of the function being called.
+    public init(
+        _type: _TypePayload,
+        itemId: Swift.String,
+        outputIndex: Swift.Int,
+        sequenceNumber: Swift.Int,
+        arguments: Swift.String,
+        name: Swift.String? = nil
+    ) {
+        self._type = _type
+        self.itemId = itemId
+        self.outputIndex = outputIndex
+        self.sequenceNumber = sequenceNumber
+        self.arguments = arguments
+        self.name = name
+    }
+    public enum CodingKeys: String, CodingKey {
+        case _type = "type"
+        case itemId = "item_id"
+        case outputIndex = "output_index"
+        case sequenceNumber = "sequence_number"
+        case arguments
+        case name
+    }
+}

--- a/Sources/OpenAI/Public/Schemas/Facade/ResponseStreamEvent.swift
+++ b/Sources/OpenAI/Public/Schemas/Facade/ResponseStreamEvent.swift
@@ -56,7 +56,7 @@ public enum ResponseStreamEvent: Codable, Equatable, Sendable {
         /// Emitted when there is a partial function-call arguments delta.
         case delta(Schemas.ResponseFunctionCallArgumentsDeltaEvent)
         /// Emitted when function-call arguments are finalized.
-        case done(Schemas.ResponseFunctionCallArgumentsDoneEvent)
+        case done(ResponseFunctionCallArgumentsDoneEvent)
     }
     
     public enum FileSearchCallEvent: Codable, Equatable, Sendable {
@@ -274,7 +274,18 @@ public enum ResponseStreamEvent: Codable, Equatable, Sendable {
         } catch {
             //
         }
-        
+
+        // Decoding ResponseFunctionCallArgumentsDoneEvent via the locally
+        // extracted type so that `name` (missing from the generated schema)
+        // is preserved.
+        do {
+            let functionCallDoneEvent = try ResponseFunctionCallArgumentsDoneEvent(from: decoder)
+            self = .functionCallArguments(.done(functionCallDoneEvent))
+            return
+        } catch {
+            //
+        }
+
         let rawEvent = try Components.Schemas.ResponseStreamEvent(from: decoder)
         if rawEvent.value10 != nil || rawEvent.value13 != nil || rawEvent.value20 != nil || rawEvent.value21 != nil, rawEvent.value22 != nil, rawEvent.value40 != nil, rawEvent.value41 != nil, rawEvent.value49 != nil {
             // The following events are handled elsewhere by non-generated types
@@ -329,7 +340,14 @@ public enum ResponseStreamEvent: Codable, Equatable, Sendable {
         } else if let value = rawEvent.value18 {
             self = .functionCallArguments(.delta(value))
         } else if let value = rawEvent.value19 {
-            self = .functionCallArguments(.done(value))
+            self = .functionCallArguments(.done(.init(
+                _type: .response_functionCallArguments_done,
+                itemId: value.itemId,
+                outputIndex: value.outputIndex,
+                sequenceNumber: value.sequenceNumber,
+                arguments: value.arguments,
+                name: nil
+            )))
         } else if let value = rawEvent.value25 {
             self = .reasoningSummaryPart(.added(value))
         } else if let value = rawEvent.value26 {

--- a/Tests/OpenAITests/ResponseFunctionCallArgumentsDoneEventTests.swift
+++ b/Tests/OpenAITests/ResponseFunctionCallArgumentsDoneEventTests.swift
@@ -1,0 +1,87 @@
+//
+//  ResponseFunctionCallArgumentsDoneEventTests.swift
+//  OpenAI
+//
+
+import XCTest
+@testable import OpenAI
+
+final class ResponseFunctionCallArgumentsDoneEventTests: XCTestCase {
+    func testDecodesNameField() throws {
+        let json = """
+        {
+          "type": "response.function_call_arguments.done",
+          "item_id": "item-abc",
+          "name": "get_weather",
+          "output_index": 1,
+          "arguments": "{ \\"arg\\": 123 }",
+          "sequence_number": 1
+        }
+        """.data(using: .utf8)!
+
+        let event = try JSONDecoder().decode(ResponseFunctionCallArgumentsDoneEvent.self, from: json)
+        XCTAssertEqual(event._type, .response_functionCallArguments_done)
+        XCTAssertEqual(event.itemId, "item-abc")
+        XCTAssertEqual(event.outputIndex, 1)
+        XCTAssertEqual(event.sequenceNumber, 1)
+        XCTAssertEqual(event.arguments, "{ \"arg\": 123 }")
+        XCTAssertEqual(event.name, "get_weather")
+    }
+
+    func testDecodesWithoutNameField() throws {
+        let json = """
+        {
+          "type": "response.function_call_arguments.done",
+          "item_id": "item-abc",
+          "output_index": 1,
+          "arguments": "{}",
+          "sequence_number": 1
+        }
+        """.data(using: .utf8)!
+
+        let event = try JSONDecoder().decode(ResponseFunctionCallArgumentsDoneEvent.self, from: json)
+        XCTAssertNil(event.name)
+    }
+
+    func testRoundTripPreservesName() throws {
+        let original = ResponseFunctionCallArgumentsDoneEvent(
+            _type: .response_functionCallArguments_done,
+            itemId: "item-abc",
+            outputIndex: 2,
+            sequenceNumber: 5,
+            arguments: "{\"a\":1}",
+            name: "lookup_user"
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ResponseFunctionCallArgumentsDoneEvent.self, from: encoded)
+        XCTAssertEqual(decoded, original)
+
+        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(try XCTUnwrap(dict["name"] as? String), "lookup_user")
+        XCTAssertEqual(try XCTUnwrap(dict["type"] as? String), "response.function_call_arguments.done")
+    }
+
+    func testResponseStreamEventFacadeExposesName() throws {
+        let json = """
+        {
+          "type": "response.function_call_arguments.done",
+          "item_id": "item-abc",
+          "name": "get_weather",
+          "output_index": 1,
+          "arguments": "{}",
+          "sequence_number": 7
+        }
+        """.data(using: .utf8)!
+
+        let event = try JSONDecoder().decode(ResponseStreamEvent.self, from: json)
+        switch event {
+        case .functionCallArguments(.done(let doneEvent)):
+            XCTAssertEqual(doneEvent.name, "get_weather")
+            XCTAssertEqual(doneEvent.itemId, "item-abc")
+            XCTAssertEqual(doneEvent.sequenceNumber, 7)
+        default:
+            XCTFail("Expected .functionCallArguments(.done), got \(event)")
+        }
+    }
+}


### PR DESCRIPTION
## What

The `response.function_call_arguments.done` streaming event is documented by OpenAI as carrying a `name` field identifying the function whose arguments have been finalized:

```json
{
  "type": "response.function_call_arguments.done",
  "item_id": "item-abc",
  "name": "get_weather",
  "output_index": 1,
  "arguments": "{ \"arg\": 123 }",
  "sequence_number": 1
}
```

The generated `Components.Schemas.ResponseFunctionCallArgumentsDoneEvent` is missing it (the upstream OpenAPI spec lags), so SDK users couldn't read the function name from this event.

This PR:
- Extracts the type to `Sources/OpenAI/Public/Schemas/Edited/ResponseFunctionCallArgumentsDoneEvent.swift` with a new `public var name: Swift.String?` field, following the documented pattern in CONTRIBUTING.md ("Extracting a generated Type") and the existing precedent for `ResponseMCPCallArgumentsDoneEvent`.
- Updates the `ResponseStreamEvent` facade so `.functionCallArguments(.done(_))` carries the extracted type. Adds an early decode block (mirroring the MCP one) so JSON with `name` round-trips correctly. Preserves the existing `rawEvent.value19` fallback by converting from the generated type to the new one (with `name: nil`).

## Why

Closes #409. Function-call routing on the Responses API requires knowing which function the arguments belong to. Without `name`, consumers had to track it externally via the surrounding `output_item.added` event, which is brittle.

## Affected Areas

- New file: `Sources/OpenAI/Public/Schemas/Edited/ResponseFunctionCallArgumentsDoneEvent.swift`
- Modified: `Sources/OpenAI/Public/Schemas/Facade/ResponseStreamEvent.swift`
  - Enum case type changed from `Schemas.ResponseFunctionCallArgumentsDoneEvent` to the new top-level `ResponseFunctionCallArgumentsDoneEvent`.
  - Added an early-decode block before the `rawEvent` fallback.
  - The `rawEvent.value19` branch now bridges to the extracted type so the fallback path stays valid.
- New tests: `Tests/OpenAITests/ResponseFunctionCallArgumentsDoneEventTests.swift` — decode-with-name, decode-without-name, round-trip, and an end-to-end check through `ResponseStreamEvent`.

## More Info

- Source-compat note: pattern-matched code using `.functionCallArguments(.done(let event))` continues to compile (all the original fields are still present on the new type); only the static type of `event` changes. Code that explicitly annotated the bound variable as `Components.Schemas.ResponseFunctionCallArgumentsDoneEvent` would need to drop the annotation or switch to the new type.
- `name` is modeled as optional `String?` for forward-compat with servers that haven't shipped the field yet.
- Local: `swift build` clean; full `swift test` is 183 passed / 0 failed (4 new tests for this event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)