### PR TITLE
docs: add Tuning Engines custom host example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ This SDK is more focused on working with OpenAI Platform, but also works with ot
 
 Use `.relaxed` parsing option on Configuration, or see more details on the topic [here](#support-for-other-providers)
 
+For example, you can route requests through Tuning Engines when your app uses a governed OpenAI-compatible endpoint for model access, policy checks, audit logs, traces, and usage/cost reporting:
+
+```swift
+let configuration = OpenAI.Configuration(
+    token: ProcessInfo.processInfo.environment["TUNING_ENGINES_API_KEY"],
+    host: "api.tuningengines.com",
+    basePath: "/v1",
+    parsingOptions: .relaxed
+)
+let openAI = OpenAI(configuration: configuration)
+```
+
 ### Cancelling requests
 
 For Swift Concurrency calls, you can simply cancel the calling task, and corresponding underlying `URLSessionDataTask` would get cancelled automatically.


### PR DESCRIPTION
## Summary
- add a Tuning Engines example to the existing OpenAI-compatible providers section
- show Configuration with host, basePath, environment API key, and relaxed parsing
- keep the change limited to documentation

## Why
We are an AI infrastructure team using this Swift SDK with Tuning Engines. Since the README already documents custom hosts and OpenAI-compatible providers, this adds a concrete setup for teams that want governed model access, policy checks, traces, audit logs, and usage/cost reporting. It would mean a lot to us if this is useful, and I am happy to adjust or shorten the wording.

## Validation
- git diff --check
- checked OpenAI.Configuration supports host, basePath, and parsingOptions